### PR TITLE
Allow bundler to use deploy keys to pull from remote repo

### DIFF
--- a/lib/engineyard-serverside/configuration.rb
+++ b/lib/engineyard-serverside/configuration.rb
@@ -81,6 +81,10 @@ module EY
         configuration['group'] || user
       end
 
+      def ssh_private_key
+        configuration['ssh_private_key'] || "/home/#{user}/.ssh/#{app}-deploy-key"
+      end
+
       def role
         node['instance_role']
       end

--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -142,7 +142,7 @@ module EY
 
           sudo "#{$0} _#{EY::Serverside::VERSION}_ install_bundler #{bundler_installer.version}"
 
-          run "cd #{c.release_path} && bundle _#{bundler_installer.version}_ install #{bundler_installer.options}"
+          run "exec ssh-agent bash -c 'ssh-add #{c.ssh_private_key} && cd #{c.release_path} && bundle _#{bundler_installer.version}_ install #{bundler_installer.options}'"
         end
       end
 

--- a/spec/real_deploy_spec.rb
+++ b/spec/real_deploy_spec.rb
@@ -112,6 +112,7 @@ describe "deploying an application" do
     # we're probably running this spec under bundler, but a real
     # deploy does not
     def bundle
+      `ssh-keygen -N "" -f #{c.ssh_private_key}`
       my_env = ENV.to_hash
 
       ENV.delete("BUNDLE_GEMFILE")
@@ -140,13 +141,14 @@ describe "deploying an application" do
 
     # run a deploy
     config = EY::Serverside::Deploy::Configuration.new({
-        "strategy"      => "IntegrationSpec",
-        "deploy_to"     => @deploy_dir,
-        "group"         => `id -gn`.strip,
-        "stack"         => 'nginx_passenger',
-        "migrate"       => "ruby -e 'puts ENV[\"PATH\"]' > #{@deploy_dir}/path-when-migrating",
-        'app'           => 'foo',
-        'framework_env' => 'staging'
+        "strategy"        => "IntegrationSpec",
+        "deploy_to"       => @deploy_dir,
+        "group"           => `id -gn`.strip,
+        "stack"           => 'nginx_passenger',
+        "migrate"         => "ruby -e 'puts ENV[\"PATH\"]' > #{@deploy_dir}/path-when-migrating",
+        'app'             => 'foo',
+        'framework_env'   => 'staging',
+        'ssh_private_key' => File.join(@deploy_dir, "ssh_key")
       })
 
     @binpath = $0 = File.expand_path(File.join(File.dirname(__FILE__), '..', 'bin', 'engineyard-serverside'))


### PR DESCRIPTION
All I'm doing is wrapping the call to bundler in an ssh-agent that has added the key.  I fixed the integration spec so that it still passes, although I didn't add a spec for this specific use-case.  To make the integration test work, I made a configuration option for "ssh_private_key".  See also https://support.cloud.engineyard.com/requests/19893 and https://gist.github.com/768022  Let me know if this gets pulled and deployed, so I can delete my config/eydeploy.rb.  Thanks!  :)
