### PR TITLE
Clear bundled_gems if a different Ruby or System version is detected

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -142,7 +142,27 @@ module EY
 
           sudo "#{$0} _#{EY::Serverside::VERSION}_ install_bundler #{bundler_installer.version}"
 
+          bundled_gems_path = File.join(c.shared_path, "bundled_gems")
+          ruby_version_file = File.join(bundled_gems_path, "RUBY_VERSION")
+          system_version_file = File.join(bundled_gems_path, "SYSTEM_VERSION")
+          ruby_version = `ruby -v`
+          system_version = `uname -m`
+
+          if File.directory?(bundled_gems_path)
+            rebundle = false
+
+            rebundle = true if File.exist?(ruby_version_file) && File.read(ruby_version_file) != ruby_version
+            rebundle = true if File.exist?(system_version_file) && File.read(system_version_file) != system_version
+
+            if rebundle
+              info "~> Ruby version change detected, cleaning bundled gems"
+              run "rm -Rf #{bundled_gems_path}"
+            end
+          end
+
           run "cd #{c.release_path} && bundle _#{bundler_installer.version}_ install #{bundler_installer.options}"
+
+          run "mkdir -p #{bundled_gems_path} && ruby -v > #{ruby_version_file} && uname -m > #{system_version_file}"
         end
       end
 


### PR DESCRIPTION
This helps with a few cases where bundler does not reinstall gems, for
example when upgrading from 32-bit to 64-bit, or when changing the Ruby
version. By clearing the entire bundled_gems directory we can ensure
that all gems are reinstalled properly.
