### PR TITLE
Refactor list of roles that assets are compiled on

### DIFF
--- a/lib/engineyard-serverside/rails_asset_support.rb
+++ b/lib/engineyard-serverside/rails_asset_support.rb
@@ -4,7 +4,7 @@ module EY
       def compile_assets
         return unless app_needs_assets?
         rails_version = bundled_rails_version
-        roles :app_master, :app, :solo do
+        roles asset_roles do
           keep_existing_assets
           cmd = "cd #{c.release_path} && PATH=#{c.binstubs_path}:$PATH #{c.framework_envs} rake assets:precompile"
 
@@ -119,6 +119,12 @@ ln -nfs #{current} #{last_asset_path} #{c.release_path}/public
           return $2 if $1 == 'rails'
         end
         nil
+      end
+
+      protected
+
+      def asset_roles
+        [:app_master, :app, :solo]
       end
     end
   end


### PR DESCRIPTION
By moving the list of server-roles that the Rails assets are compiled on to a method, it's possible to override this method with your own set of roles. This for instance makes it possible to also compile assets on a util-server.

For details of how to override, see:
https://support.cloud.engineyard.com/entries/20996661-customize-your-deployment#second

An simple use-case could be if you generate and e-mail PDF's using a background job. If these PDF's contain images or other assets that needs to be compiled into the PDF, these assets needs to be compiled and available on the utility server.
