### PR TITLE
Compile assets before the migration page is enabled

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -34,9 +34,9 @@ module EY
           check_for_ey_config
           symlink_configs
           setup_sqlite3_if_necessary
+          run_with_callbacks(:compile_assets) # defined in RailsAssetSupport
           enable_maintenance_page
           run_with_callbacks(:migrate)
-          run_with_callbacks(:compile_assets) # defined in RailsAssetSupport
           callback(:before_symlink)
           # We don't use run_with_callbacks for symlink because we need
           # to clean up manually if it fails.


### PR DESCRIPTION
With Rails 3.1, asset compilation can take a very long time. If you deploy with migrations (-m), the maintenance page would be enabled BEFORE the assets was compiled and the site would be off-line. There is no need for the maintenance page to be enabled until after the assets have been compiled
