### PR TITLE
Allow overriding on which roles to precompile assets

### DIFF
--- a/lib/engineyard-serverside/rails_asset_support.rb
+++ b/lib/engineyard-serverside/rails_asset_support.rb
@@ -4,7 +4,7 @@ module EY
       def compile_assets
         return unless app_needs_assets?
         rails_version = bundled_rails_version
-        roles :app_master, :app, :solo do
+        roles asset_roles do
           keep_existing_assets
           cmd = "cd #{config.paths.active_release} && PATH=#{config.paths.binstubs}:$PATH #{config.framework_envs} rake assets:precompile"
 
@@ -125,6 +125,13 @@ ln -nfs #{current} #{last_asset_path} #{config.paths.public}
           return $2 if $1 == 'rails'
         end
         nil
+      end
+
+      protected
+
+      # Override this to customize on which roles to precompile assets
+      def asset_roles
+        [:app_master, :app, :solo]
       end
     end
   end

--- a/spec/rails31_deploy_spec.rb
+++ b/spec/rails31_deploy_spec.rb
@@ -53,4 +53,35 @@ describe "Deploying a Rails 3.1 application" do
       deploy_dir.join('current', 'public', 'assets').should_not be_symlink
     end
   end
+
+  context "without custom asset roles" do
+    before(:all) do
+      # I am not sure how to simulate running the deploy on a util server.
+      # How would I go about doing that?
+      deploy_test_application('assets_enabled')
+    end
+
+    it "does not precompile assets on util instances" do
+      deploy_dir.join('current', 'precompiled').should_not exist
+    end
+  end
+
+  context "with custom asset roles" do
+    module ::EY::Serverside::RailsAssetSupport
+      protected
+      def asset_roles
+        [:app_master, :app, :solo, :util]
+      end
+    end
+
+    before(:all) do
+      # I am not sure how to simulate running the deploy on a util server.
+      # How would I go about doing that?
+      deploy_test_application('assets_enabled')
+    end
+
+    it "precompiles assets on util instances" do
+      deploy_dir.join('current', 'precompiled').should exist
+    end
+  end
 end


### PR DESCRIPTION
This allows you to easily override on which roles to precompile assets in your eydeploy.rb file by simply opening up the `EY::Serverside::RailsAssetSupport` module and redefining the `asset_roles` method without having to override the entire `compile_assets` method

This is a replacement for #37, which can be closed.

**Example:**

``` ruby
module ::EY::Serverside::RailsAssetSupport
  protected
  def asset_roles
    [:app_master, :app, :solo, :util]
  end
end
```

**Please note the failing specs!**
I wasn't sure how to simulate the deploy running on a util-instance.
Could someone give me a hint?
