### PR TITLE
use bundler for testing, add gems required for tests

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,20 @@ The ey.yml file allows options to be saved for each environment to which an appl
 
 These options in ey.yml will only work if the file is committed to your application repository. Make sure to commit this file.
 
-### Running the spec suite
+### Running the spec suite (ruby 1.8.7+)
+
+Install required gems:
+
+    which bundle >/dev/null || gem install bundler
+    bundle install
+
+Running tests:
+
+    bundle exec rake
+
+Bundler will take care of installing and running proper (older versions) of gems.
+
+### Running the spec suite (ruby 1.8.6)
 
 Bundler doesn't work on ruby 1.8.6-p287, which is what 'ey\_resin' currently provides.
 To test engineyard-serverside under the same ruby, you can run:

--- a/engineyard-serverside.gemspec
+++ b/engineyard-serverside.gemspec
@@ -18,11 +18,13 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_development_dependency('rspec', '1.3.2')
-  s.add_development_dependency('rake', '>=0.9.2.2')
+  s.add_development_dependency('rake', '>=0.9.2.2', '<10.0')
   s.add_development_dependency('rdoc')
   s.add_development_dependency('timecop')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('engineyard-cloud-client', '~>1.0.5')
+  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('pg', '0.13.2')
 
   s.required_rubygems_version = %q{>= 1.3.6}
   s.test_files = Dir.glob("spec/**/*")


### PR DESCRIPTION
Summary:
- rake `0.9` is required, the tests will not run on `10.0`
- add development dependency on database gems - they are required for tests
- add bundler instructions - solves wrong gem version loading problems
