### PR TITLE
Run the deploy hooks when bundling on rollback

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -190,7 +190,7 @@ chmod 0700 #{path}
             shell.status "Rolling back to previous release: #{short_log_message(config.active_revision)}"
             run_with_callbacks(:symlink)
             sudo "rm -rf #{rolled_back_release}"
-            bundle
+            run_with_callbacks(:bundle)
             shell.status "Restarting with previous release."
             enable_maintenance_page
             run_with_callbacks(:restart)


### PR DESCRIPTION
Currently the hooks are not run for the bundle step when running a rollback, this fixes that.
