### PR TITLE
Composer support (PHP dependency manager)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,11 @@ Spec::Rake::SpecTask.new(:spec) do |spec|
 end
 task :default => :spec
 
+Spec::Rake::SpecTask.new(:php) do |spec|
+  spec.libs << 'lib' << 'spec'
+  spec.spec_files = FileList['spec/php_deploy_spec.rb']
+end
+
 task :coverage => [:coverage_env, :spec]
 task :coverage_env do
   ENV['COVERAGE'] = '1'

--- a/lib/engineyard-serverside/dependency_manager.rb
+++ b/lib/engineyard-serverside/dependency_manager.rb
@@ -2,6 +2,7 @@ require 'engineyard-serverside/dependency_manager/base'
 require 'engineyard-serverside/dependency_manager/bundler'
 require 'engineyard-serverside/dependency_manager/bundler_lock'
 require 'engineyard-serverside/dependency_manager/npm'
+require 'engineyard-serverside/dependency_manager/composer'
 
 module EY
   module Serverside
@@ -10,6 +11,7 @@ module EY
         Bundler.detect(servers, config, shell, runner) ||
         BundlerLock.detect(servers, config, shell, runner) ||
           Npm.detect(servers, config, shell, runner) ||
+          Composer.detect(servers, config, shell, runner) ||
           Base.new(servers, config, shell, runner)
       end
     end

--- a/lib/engineyard-serverside/dependency_manager/composer.rb
+++ b/lib/engineyard-serverside/dependency_manager/composer.rb
@@ -1,0 +1,41 @@
+module EY
+  module Serverside
+    module DependencyManager
+      class Composer < Base
+        def detected?
+           composer_lock? || composer_json?
+        end
+
+        def install
+          if composer_available?
+            shell.status "Installing composer packages (composer.#{lock_or_json} detected)"
+            run "composer install --no-interaction --working-dir #{paths.active_release}"
+          else
+            shell.warning "composer.#{lock_or_json} detected but composer not available."
+          end
+        end
+
+        def lock_or_json
+          composer_lock? ? 'lock' : 'json'
+        end
+
+        def composer_lock?
+          paths.composer_lock.exist?
+        end
+
+        def composer_json?
+          paths.composer_json.exist?
+        end
+
+        def composer_available?
+          begin
+            run "command -v composer > /dev/null"
+            return true
+          rescue EY::Serverside::RemoteFailure
+            return false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engineyard-serverside/paths.rb
+++ b/lib/engineyard-serverside/paths.rb
@@ -82,6 +82,8 @@ module EY
       def_path :public_assets,            [:public, 'assets']
       def_path :public_system,            [:public, 'system']
       def_path :package_json,             [:active_release, 'package.json']
+      def_path :composer_json,            [:active_release, 'composer.json']
+      def_path :composer_lock,            [:active_release, 'composer.lock']
       def_path :active_release_config,    [:active_release, 'config']
       def_path :active_log,               [:active_release, 'log']
 

--- a/spec/fixtures/repos/php_composer_lock/README
+++ b/spec/fixtures/repos/php_composer_lock/README
@@ -1,0 +1,1 @@
+Simple PHP Composer app.

--- a/spec/fixtures/repos/php_composer_lock/composer.json
+++ b/spec/fixtures/repos/php_composer_lock/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "1.2.*"
+    }
+}

--- a/spec/fixtures/repos/php_composer_lock/composer.lock
+++ b/spec/fixtures/repos/php_composer_lock/composer.lock
@@ -1,0 +1,462 @@
+{
+    "hash": "6481f6a258c344122ba0157d5eadc0fd",
+    "packages": [
+        {
+            "name": "bjyoungblood/bjy-authorize",
+            "version": "1.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bjyoungblood/BjyAuthorize.git",
+                "reference": "1.2.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bjyoungblood/BjyAuthorize/zipball/1.2.6",
+                "reference": "1.2.6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zend-permissions-acl": ">=2.1,<3.0",
+                "zendframework/zend-mvc": ">=2.1,<3.0",
+                "zendframework/zend-eventmanager": ">=2.1,<3.0",
+                "zendframework/zend-servicemanager": ">=2.1,<3.0",
+                "zendframework/zend-view": ">=2.1,<3.0"
+            },
+            "require-dev": {
+                "doctrine/common": ">=2.3,<2.5-dev",
+                "zendframework/zend-developer-tools": "0.*",
+                "zf-commons/zfc-user": "0.*"
+            },
+            "time": "2013-05-12 16:07:25",
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "installation-source": "dist",
+            "autoload": {
+                "psr-0": {
+                    "BjyAuthorize\\": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ben Youngblood",
+                    "email": "bx.youngblood@gmail.com",
+                    "homepage": "http://bjyoungblood.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Zend\\Acl based firewall system for ZF2 dispatch protection",
+            "homepage": "https://github.com/bjyoungblood/BjyAuthorize",
+            "keywords": [
+                "zf2",
+                "acl",
+                "zfc-user"
+            ]
+        },
+        {
+            "name": "bjyoungblood/bjy-profiler",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bjyoungblood/BjyProfiler.git",
+                "reference": "1ca31611b6960bcd744dced95764e3627e8d807a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bjyoungblood/BjyProfiler/zipball/1ca31611b6960bcd744dced95764e3627e8d807a",
+                "reference": "1ca31611b6960bcd744dced95764e3627e8d807a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "zendframework/zendframework": ">=2.1.0"
+            },
+            "time": "1364225067",
+            "type": "library",
+            "installation-source": "source",
+            "autoload": {
+                "psr-0": {
+                    "BjyProfiler": "src/"
+                },
+                "classmap": [
+                    "./Module.php"
+                ]
+            },
+            "authors": [
+                {
+                    "name": "Ben Youngblood",
+                    "email": "bx.youngblood@gmail.com",
+                    "homepage": "http://bjyoungblood.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Database profiler for Zend\\Db (also plugin for ZendDeveloperTools)",
+            "homepage": "https://github.com/bjyoungblood/BjyProfiler",
+            "keywords": [
+                "db",
+                "zf2",
+                "profiler",
+                "zdt"
+            ]
+        },
+        {
+            "name": "darkmatus/roleuserbridge",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dshafik/roleuserbridge",
+                "reference": "9f70ef6f24e75c6592f769bd0cd598f135108f48"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/dshafik/roleuserbridge/zipball/9f70ef6f24e75c6592f769bd0cd598f135108f48",
+                "reference": "9f70ef6f24e75c6592f769bd0cd598f135108f48",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zendframework": "2.*",
+                "zf-commons/zfc-base": "0.1.*",
+                "zf-commons/zfc-user": "0.1.*",
+                "bjyoungblood/bjy-authorize": "1.2.*"
+            },
+            "time": "1365313580",
+            "type": "library",
+            "installation-source": "source",
+            "autoload": {
+                "psr-0": {
+                    "RoleUserBridge": "src/"
+                },
+                "classmap": [
+                    "./"
+                ]
+            },
+            "authors": [
+                {
+                    "name": "Darkmatus",
+                    "email": "mueller@s-p-it.de",
+                    "homepage": "https://github.com/darkmatus/"
+                }
+            ],
+            "description": "ZfcUser/BjyAuthorize Bridge for auto-adding User to the user_role_table from BjyAuthorize.",
+            "homepage": "https://github.com/darkmatus/roleuserbridge",
+            "keywords": [
+                "zf2"
+            ],
+            "support": {
+                "source": "https://github.com/dshafik/roleuserbridge/tree/master"
+            }
+        },
+        {
+            "name": "zendframework/zend-developer-tools",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/ZendDeveloperTools",
+                "reference": "9e2cf51ffbd3778f07be4a245e6b7a84a6a18a1c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/zendframework/ZendDeveloperTools/zipball/9e2cf51ffbd3778f07be4a245e6b7a84a6a18a1c",
+                "reference": "9e2cf51ffbd3778f07be4a245e6b7a84a6a18a1c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zend-mvc": "2.*",
+                "zendframework/zend-eventmanager": "2.*",
+                "zendframework/zend-stdlib": "2.*",
+                "zendframework/zend-servicemanager": "2.*",
+                "zendframework/zend-version": "2.*"
+            },
+            "suggest": {
+                "bjyoungblood/bjy-profiler": "Version: dev-master, allows the usage of the (Zend) Db collector."
+            },
+            "time": "1368974025",
+            "type": "zf-module",
+            "installation-source": "source",
+            "autoload": {
+                "psr-0": {
+                    "ZendDeveloperTools": "src/"
+                },
+                "classmap": [
+                    "./Module.php"
+                ]
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Coury",
+                    "email": "me@evancoury.com",
+                    "homepage": "http://blog.evan.pro/"
+                },
+                {
+                    "name": "Eric Boh",
+                    "email": "cossish@gmail.com"
+                }
+            ],
+            "description": "Module for developer and debug tools for working with the ZF2 MVC layer.",
+            "homepage": "https://github.com/zendframework/ZendDeveloperTools",
+            "keywords": [
+                "debug",
+                "developer",
+                "zf2",
+                "module"
+            ],
+            "support": {
+                "source": "https://github.com/zendframework/ZendDeveloperTools/tree/master",
+                "issues": "https://github.com/zendframework/ZendDeveloperTools/issues"
+            }
+        },
+        {
+            "name": "zendframework/zendframework",
+            "version": "2.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zf2.git",
+                "reference": "release-2.1.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zf2/zipball/release-2.1.5",
+                "reference": "release-2.1.5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "replace": {
+                "zendframework/zend-authentication": "self.version",
+                "zendframework/zend-barcode": "self.version",
+                "zendframework/zend-cache": "self.version",
+                "zendframework/zend-captcha": "self.version",
+                "zendframework/zend-code": "self.version",
+                "zendframework/zend-config": "self.version",
+                "zendframework/zend-console": "self.version",
+                "zendframework/zend-crypt": "self.version",
+                "zendframework/zend-db": "self.version",
+                "zendframework/zend-debug": "self.version",
+                "zendframework/zend-di": "self.version",
+                "zendframework/zend-dom": "self.version",
+                "zendframework/zend-escaper": "self.version",
+                "zendframework/zend-eventmanager": "self.version",
+                "zendframework/zend-feed": "self.version",
+                "zendframework/zend-file": "self.version",
+                "zendframework/zend-filter": "self.version",
+                "zendframework/zend-form": "self.version",
+                "zendframework/zend-http": "self.version",
+                "zendframework/zend-i18n": "self.version",
+                "zendframework/zend-inputfilter": "self.version",
+                "zendframework/zend-json": "self.version",
+                "zendframework/zend-ldap": "self.version",
+                "zendframework/zend-loader": "self.version",
+                "zendframework/zend-log": "self.version",
+                "zendframework/zend-mail": "self.version",
+                "zendframework/zend-math": "self.version",
+                "zendframework/zend-memory": "self.version",
+                "zendframework/zend-mime": "self.version",
+                "zendframework/zend-modulemanager": "self.version",
+                "zendframework/zend-mvc": "self.version",
+                "zendframework/zend-navigation": "self.version",
+                "zendframework/zend-paginator": "self.version",
+                "zendframework/zend-permissions-acl": "self.version",
+                "zendframework/zend-permissions-rbac": "self.version",
+                "zendframework/zend-progressbar": "self.version",
+                "zendframework/zend-serializer": "self.version",
+                "zendframework/zend-server": "self.version",
+                "zendframework/zend-servicemanager": "self.version",
+                "zendframework/zend-session": "self.version",
+                "zendframework/zend-soap": "self.version",
+                "zendframework/zend-stdlib": "self.version",
+                "zendframework/zend-tag": "self.version",
+                "zendframework/zend-test": "self.version",
+                "zendframework/zend-text": "self.version",
+                "zendframework/zend-uri": "self.version",
+                "zendframework/zend-validator": "self.version",
+                "zendframework/zend-version": "self.version",
+                "zendframework/zend-view": "self.version",
+                "zendframework/zend-xmlrpc": "self.version"
+            },
+            "require-dev": {
+                "doctrine/common": ">=2.1",
+                "ircmaxell/random-lib": "dev-master",
+                "ircmaxell/security-lib": "dev-master",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "suggest": {
+                "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
+                "ext-intl": "ext/intl for i18n features",
+                "ircmaxell/random-lib": "Fallback random byte generator for Zend\\Math\\Rand if OpenSSL/Mcrypt extensions are unavailable",
+                "pecl-weakref": "Implementation of weak references for Zend\\Stdlib\\CallbackHandler",
+                "zendframework/zendpdf": "ZendPdf for creating PDF representations of barcodes",
+                "zendframework/zendservice-recaptcha": "ZendService\\ReCaptcha for rendering ReCaptchas in Zend\\Captcha and/or Zend\\Form"
+            },
+            "time": "2013-04-17 15:15:58",
+            "bin": [
+                "bin/classmap_generator.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev",
+                    "dev-develop": "2.2-dev"
+                }
+            },
+            "installation-source": "dist",
+            "autoload": {
+                "psr-0": {
+                    "Zend\\": "library/",
+                    "ZendTest\\": "tests/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework 2",
+            "homepage": "http://framework.zend.com/",
+            "keywords": [
+                "framework",
+                "zf2"
+            ]
+        },
+        {
+            "name": "zf-commons/zfc-base",
+            "version": "v0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ZF-Commons/ZfcBase.git",
+                "reference": "v0.1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ZF-Commons/ZfcBase/zipball/v0.1.2",
+                "reference": "v0.1.2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zend-db": ">=2.1,<3.0",
+                "zendframework/zend-eventmanager": ">=2.1,<3.0",
+                "zendframework/zend-loader": ">=2.1,<3.0",
+                "zendframework/zend-modulemanager": ">=2.1,<3.0",
+                "zendframework/zend-mvc": ">=2.1,<3.0",
+                "zendframework/zend-servicemanager": ">=2.1,<3.0",
+                "zendframework/zend-stdlib": ">=2.1,<3.0"
+            },
+            "time": "2013-05-02 12:33:49",
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-0": {
+                    "ZfcBase": "src/"
+                },
+                "classmap": [
+                    "./Module.php"
+                ]
+            },
+            "authors": [
+                {
+                    "name": "Kyle Spraggs",
+                    "email": "theman@spiffyjr.me",
+                    "homepage": "http://www.spiffyjr.me/"
+                },
+                {
+                    "name": "Evan Coury",
+                    "email": "me@evancoury.com",
+                    "homepage": "http://blog.evan.pro/"
+                }
+            ],
+            "description": "A set of genetic (abstract) classes which are commonly used across multiple modules.",
+            "homepage": "https://github.com/ZF-Commons/ZfcBase",
+            "keywords": [
+                "zf2"
+            ]
+        },
+        {
+            "name": "zf-commons/zfc-user",
+            "version": "0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ZF-Commons/ZfcUser.git",
+                "reference": "0.1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ZF-Commons/ZfcUser/zipball/0.1.2",
+                "reference": "0.1.2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zend-authentication": ">=2.1,<3.0",
+                "zendframework/zend-crypt": ">=2.1,<3.0",
+                "zendframework/zend-form": ">=2.1,<3.0",
+                "zendframework/zend-inputfilter": ">=2.1,<3.0",
+                "zendframework/zend-loader": ">=2.1,<3.0",
+                "zendframework/zend-modulemanager": ">=2.1,<3.0",
+                "zendframework/zend-mvc": ">=2.1,<3.0",
+                "zendframework/zend-servicemanager": ">=2.1,<3.0",
+                "zendframework/zend-stdlib": ">=2.1,<3.0",
+                "zendframework/zend-validator": ">=2.1,<3.0",
+                "zendframework/zend-view": ">=2.1,<3.0",
+                "zf-commons/zfc-base": "0.*"
+            },
+            "suggest": {
+                "zendframework/zend-session": "To use the default authentication adapter."
+            },
+            "time": "2013-05-02 12:33:31",
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-0": {
+                    "ZfcUser": "src/"
+                },
+                "classmap": [
+                    "./Module.php"
+                ]
+            },
+            "authors": [
+                {
+                    "name": "Kyle Spraggs",
+                    "email": "theman@spiffyjr.me",
+                    "homepage": "http://www.spiffyjr.me/"
+                },
+                {
+                    "name": "Evan Coury",
+                    "email": "me@evancoury.com",
+                    "homepage": "http://blog.evan.pro/"
+                }
+            ],
+            "description": "A generic user registration and authentication module for ZF2. Supports Zend\\Db and Doctrine2.",
+            "homepage": "https://github.com/ZF-Commons/ZfcUser",
+            "keywords": [
+                "zf2"
+            ]
+        }
+    ],
+    "packages-dev": null,
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "zendframework/zend-developer-tools": 20,
+        "bjyoungblood/bjy-profiler": 20,
+        "darkmatus/roleuserbridge": 20
+    }
+}

--- a/spec/fixtures/repos/php_composer_lock/public/index.php
+++ b/spec/fixtures/repos/php_composer_lock/public/index.php
@@ -1,0 +1,4 @@
+<?php
+
+echo "Hello, world!";
+

--- a/spec/fixtures/repos/php_no_composer_lock/README
+++ b/spec/fixtures/repos/php_no_composer_lock/README
@@ -1,0 +1,1 @@
+Simple PHP Composer app.

--- a/spec/fixtures/repos/php_no_composer_lock/composer.json
+++ b/spec/fixtures/repos/php_no_composer_lock/composer.json
@@ -1,0 +1,21 @@
+{
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/zendframework/ZendDeveloperTools"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/dshafik/roleuserbridge"
+        }
+    ],
+    "require": {
+        "php": ">=5.4.0",
+        "zendframework/zendframework": "2.1.*",
+        "bjyoungblood/bjy-authorize": "1.2.*",
+        "zf-commons/zfc-user": "0.1.*",
+        "zendframework/zend-developer-tools": "dev-master",
+        "bjyoungblood/bjy-profiler": "dev-master",
+        "darkmatus/roleuserbridge": "dev-master"
+    }
+}

--- a/spec/fixtures/repos/php_no_composer_lock/public/index.php
+++ b/spec/fixtures/repos/php_no_composer_lock/public/index.php
@@ -1,0 +1,4 @@
+<?php
+
+echo "Hello, world!";
+

--- a/spec/php_deploy_spec.rb
+++ b/spec/php_deploy_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe "Deploying an application that uses PHP and Composer" do
+
+  context "with composer available" do
+
+    context "with a composer.lock" do
+      before(:all) do
+        deploy_test_application('php_composer_lock')
+      end
+
+      it "runs 'composer install'" do
+        install_cmd = @deployer.commands.grep(/composer install/).first
+        install_cmd.should_not be_nil
+      end
+    end
+
+    context "WITHOUT a composer.lock but with composer.json" do
+      before(:all) do
+        deploy_test_application('php_no_composer_lock')
+      end
+
+      it "runs 'composer install'" do
+        install_cmd = @deployer.commands.grep(/composer install/).first
+        install_cmd.should_not be_nil
+      end
+
+    end
+
+  end if $COMPOSER_INSTALLED
+
+  context "without composer available" do
+
+    context "with a composer.lock" do
+      before(:all) do
+        deploy_test_application('php_composer_lock')
+      end
+
+      it "outputs a warning, but continues" do
+        warning_out = read_output.should include("WARNING: composer.lock")
+        warning_out.should_not be_nil
+      end
+    end
+
+    context "WITHOUT a composer.lock but with composer.json" do
+      before(:all) do
+        deploy_test_application('php_no_composer_lock')
+      end
+
+      it "outputs a warning, but continues" do
+        warning_out = read_output.should include("WARNING: composer.json")
+        warning_out.should_not be_nil
+      end
+
+    end
+
+  end if !$COMPOSER_INSTALLED
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,13 @@ Spec::Runner.configure do |config|
     $stderr.puts "npm not found; skipping Node.js specs."
   end
 
+  $COMPOSER_INSTALLED = system('command -v composer > /dev/null')
+  if $COMPOSER_INSTALLED
+    $stderr.puts "composer found; skipping tests that expect it to be missing."
+  else
+    $stderr.puts "composer not found; skipping tests that expect it to be available."
+  end
+
   config.before(:all) do
     make_tmpdir
     EY::Serverside.dna_json = MultiJson.dump({})


### PR DESCRIPTION
This adds support for [composer](http://getcomposer.org/) to engineyard-serverside.

Detects presence of composer.json or composer.lock and uses them to install dependencies.

It will emit a warning when a composer.json or composer.lock file is detected and composer is not available.

Composer-specific tests can be run with `bundle exec rake php` - right now this runs one set of tests if composer is available on the test system, and another set if it's not. This is less than ideal, but seems like a reasonable tradeoff against a larger refactor.
