### PR TITLE
Run composer self-update before install on deploy.

### DIFF
--- a/lib/engineyard-serverside/dependency_manager/composer.rb
+++ b/lib/engineyard-serverside/dependency_manager/composer.rb
@@ -8,8 +8,10 @@ module EY
 
         def install
           if composer_available?
+            shell.status "Checking for composer updates..."
+            composer_selfupdate
             shell.status "Installing composer packages (composer.#{lock_or_json} detected)"
-            run "composer install --no-interaction --working-dir #{paths.active_release}"
+            composer_install
           else
             shell.warning "composer.#{lock_or_json} detected but composer not available."
           end
@@ -25,6 +27,14 @@ module EY
 
         def composer_json?
           paths.composer_json.exist?
+        end
+
+        def composer_install
+            run "composer install --no-interaction --working-dir #{paths.active_release}"
+        end
+
+        def composer_selfupdate
+            run "composer self-update"
         end
 
         def composer_available?

--- a/spec/php_deploy_spec.rb
+++ b/spec/php_deploy_spec.rb
@@ -13,6 +13,16 @@ describe "Deploying an application that uses PHP and Composer" do
         install_cmd = @deployer.commands.grep(/composer install/).first
         install_cmd.should_not be_nil
       end
+
+      it "runs 'composer self-update' before 'composer install'" do
+        update_cmd = nil
+        @deployer.commands.each do |cmd|
+          update_cmd ||= /composer self-update/.match(cmd)
+          if /composer install/.match(cmd)
+            update_cmd.should_not be nil
+          end
+        end
+      end
     end
 
     context "WITHOUT a composer.lock but with composer.json" do
@@ -23,6 +33,16 @@ describe "Deploying an application that uses PHP and Composer" do
       it "runs 'composer install'" do
         install_cmd = @deployer.commands.grep(/composer install/).first
         install_cmd.should_not be_nil
+      end
+
+      it "runs 'composer self-update' before 'composer install'" do
+        update_cmd = nil
+        @deployer.commands.each do |cmd|
+          update_cmd ||= /composer self-update/.match(cmd)
+          if /composer install/.match(cmd)
+            update_cmd.should_not be nil
+          end
+        end
       end
 
     end


### PR DESCRIPTION
Composer self-updates before an install. As composer appears "in alpha" according to its developers, it moves quite quickly.
