### PR TITLE
More information when an exception occurs

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -50,8 +50,8 @@ module EY
         cleanup_old_releases
         gc_repository_cache
         shell.status "Finished deploy at #{Time.now.asctime}"
-      rescue Exception
-        shell.status "Finished failing to deploy at #{Time.now.asctime}"
+      rescue Exception => e
+        shell.status "Finished failing to deploy at #{Time.now.asctime} - Exception #{e.inspect} #{e.backtrace}"
         puts_deploy_failure
         raise
       end


### PR DESCRIPTION
Hi,

We experienced a problem recently with integrating new instances and found it very difficult to debug the issue because all exceptions are caught in the main deploy code and not displayed :(

The change in this request displays the exception and trace which proved invaluable in determining the cause and ultimately resulted in a solution.

Thanks,

Ash.
