### PR TITLE
Fix rails database.yml for sqlite-only deployments

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -280,10 +280,10 @@ Deploy again if your services configuration appears incomplete or out of date.
           run <<-WRAP
 cat > #{paths.shared_config}/database.sqlite3.yml<<'YML'
 #{config.framework_env}:
-adapter: sqlite3
-database: #{paths.shared}/databases/#{config.framework_env}.sqlite3
-pool: 5
-timeout: 5000
+  adapter: sqlite3
+  database: #{paths.shared}/databases/#{config.framework_env}.sqlite3
+  pool: 5
+  timeout: 5000
 YML
           WRAP
 

--- a/spec/sqlite3_deploy_spec.rb
+++ b/spec/sqlite3_deploy_spec.rb
@@ -29,4 +29,10 @@ describe "Deploying an application with sqlite3 as the only DB adapter in the Ge
     @shared_path.join('databases', "#{@framework_env}.sqlite3").should exist
   end
 
+  it 'should contain valid yaml config' do
+    config = YAML.load_file(@release_path.join('config', 'database.yml'))
+    config[@framework_env]['adapter'].should == 'sqlite3'
+    config[@framework_env]['database'].should == @shared_path.join('databases', "#{@framework_env}.sqlite3").expand_path.to_s
+  end
+
 end


### PR DESCRIPTION
Without this fix rails does not boot, because the database.yml is broken.
