### PR TITLE
Force soft link for shared config.

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -310,7 +310,7 @@ YML
           ["Symlink shared log directory",          "ln -nfs #{paths.shared_log} #{paths.active_log}"],
           ["Symlink public system directory",       "ln -nfs #{paths.shared_system} #{paths.public_system}"],
           ["Symlink shared pids directory",         "ln -nfs #{paths.shared}/pids #{paths.active_release}/tmp/pids"],
-          ["Symlink other shared config files",     "find #{paths.shared_config} -type f -not -name 'database.yml' -exec ln -s {} #{paths.active_release_config} \\;"],
+          ["Symlink other shared config files",     "find #{paths.shared_config} -type f -not -name 'database.yml' -exec ln -nfs {} #{paths.active_release_config} \\;"],
           ["Symlink database.yml if needed",        "if [ -f \"#{paths.shared_config}/database.yml\" ]; then ln -nfs #{paths.shared_config}/database.yml #{paths.active_release_config}/database.yml; fi"],
           ["Symlink newrelic.yml if needed",        "if [ -f \"#{paths.shared_config}/newrelic.yml\" ]; then ln -nfs #{paths.shared_config}/newrelic.yml #{paths.active_release_config}/newrelic.yml; fi"],
           ["Symlink mongrel_cluster.yml if needed", "if [ -f \"#{paths.shared_config}/mongrel_cluster.yml\" ]; then ln -nfs #{paths.shared_config}/mongrel_cluster.yml #{paths.active_release_config}/mongrel_cluster.yml; fi"],


### PR DESCRIPTION
Prevents warnings like the one below and matches the style of the other calls to `ln`.

```
ln: creating symbolic link `/data/pathable/releases/20130610210849/config/elasticsearch.yml': File exists
```
