### PR TITLE
Support before_deploy and after_deploy hooks

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## NEXT
 
+  * Add hooks `before_deploy` and `after_deploy` that happen near the beginning (after release directory is created) and at the end of the deploy task. 
   * Support option --clean which will force gems to be reinstalled (eg. when making a server architecture change that isn't already caught)
   * If dependncy manager options are set to blank, treat it like "detect".
 

--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -26,6 +26,7 @@ module EY
 
         shell.status "Starting full deploy"
         copy_repository_cache
+        callback(:before_deploy)
         check_repository
 
         with_failed_release_cleanup do
@@ -49,6 +50,7 @@ module EY
 
         cleanup_old_releases
         gc_repository_cache
+        callback(:after_deploy)
         shell.status "Finished deploy at #{Time.now.asctime}"
       rescue Exception => e
         shell.status "Finished failing to deploy at #{Time.now.asctime}"

--- a/spec/deploy_hook_spec.rb
+++ b/spec/deploy_hook_spec.rb
@@ -7,6 +7,7 @@ describe "deploy hooks" do
     end
 
     it "runs all the hooks" do
+      deploy_dir.join('current', 'before_deploy.ran' ).should exist
       deploy_dir.join('current', 'before_bundle.ran' ).should exist
       deploy_dir.join('current', 'after_bundle.ran'  ).should exist
       deploy_dir.join('current', 'before_migrate.ran').should exist
@@ -17,6 +18,7 @@ describe "deploy hooks" do
       deploy_dir.join('current', 'after_symlink.ran' ).should exist
       deploy_dir.join('current', 'before_restart.ran').should exist
       deploy_dir.join('current', 'after_restart.ran' ).should exist
+      deploy_dir.join('current', 'after_deploy.ran'  ).should exist
     end
   end
 

--- a/spec/fixtures/repos/hooks/deploy/after_deploy.rb
+++ b/spec/fixtures/repos/hooks/deploy/after_deploy.rb
@@ -1,0 +1,1 @@
+run 'touch after_deploy.ran'

--- a/spec/fixtures/repos/hooks/deploy/before_deploy.rb
+++ b/spec/fixtures/repos/hooks/deploy/before_deploy.rb
@@ -1,0 +1,1 @@
+run 'touch before_deploy.ran'


### PR DESCRIPTION
These hooks are placed at the outer edges of the deploy task.

before_deploy will trigger immediately after the active_release ("releases/TIMESTAMP") directory is created on all the servers. This is the earliest it is possible to run the before hook with the expectation that the paths will be correct and usable.

after_deploy will trigger at the very end of the deploy before the script exits. This runs after maintenance pages are removed, and after the git garbage collection task.
