### PR TITLE
Integrate doesn't get the repo uri, so we can't require it

### DIFF
--- a/lib/engineyard-serverside/source/git.rb
+++ b/lib/engineyard-serverside/source/git.rb
@@ -2,7 +2,7 @@ require 'engineyard-serverside/source'
 
 # Deploy source for git repository sourced deploy.
 class EY::Serverside::Source::Git < EY::Serverside::Source
-  require_opts :uri, :ref, :repository_cache
+  require_opts :ref, :repository_cache
 
   def create_revision_file_command(revision_file_path)
     %Q{#{git} show --pretty=format:"%H" | head -1 > "#{revision_file_path}"}


### PR DESCRIPTION
Fix a bug with the integrate action where uri was required but not sent. Integrate does not require uri.

This is related to a refactoring/fix that I proposed for the next version in #68 that would let integrate be less hacky.
