### PR TITLE
Fix bug with tags that are pushed with --force

### DIFF
--- a/lib/engineyard-serverside/source/git.rb
+++ b/lib/engineyard-serverside/source/git.rb
@@ -69,7 +69,7 @@ class EY::Serverside::Source::Git < EY::Serverside::Source
 
   def fetch_command
     if usable_repository?
-      "#{git} fetch -q origin 2>&1"
+      "#{git} fetch --tags --prune --quiet origin 2>&1"
     else
       "rm -rf #{repository_cache} && git clone -q #{uri} #{repository_cache} 2>&1"
     end


### PR DESCRIPTION
When you deploy a tag that was on the wrong commit and the push a the
same tag with --force to fix it, then the cached repository doesn't prune
the old tags. This stops you from being able to deploy that tagged version.
