### PR TITLE
Add option to silence missing Gemfile.lock warning

### DIFF
--- a/lib/engineyard-serverside/configuration.rb
+++ b/lib/engineyard-serverside/configuration.rb
@@ -106,6 +106,7 @@ module EY
       def_boolean_option :gc,                              false
       def_boolean_option :precompile_unchanged_assets,     false
       def_boolean_option :ignore_database_adapter_warning, false
+      def_boolean_option :ignore_gemfile_lock_warning,     false
       def_boolean_option :eydeploy_rb,                     true
       def_boolean_option :maintenance_on_migrate,          true
       def_boolean_option(:maintenance_on_restart)          { required_downtime_stack? }

--- a/lib/engineyard-serverside/dependency_manager/bundler.rb
+++ b/lib/engineyard-serverside/dependency_manager/bundler.rb
@@ -34,7 +34,7 @@ adding ignore_database_adapter_warning: true to the application's ey.yml file
 under the defaults: top level key and committing the file to the repository.
               WARN
             end
-          else
+          elsif ! config.ignore_gemfile_lock_warning
             shell.warning <<-WARN
 Gemfile found but Gemfile.lock is missing!
 You can get different versions of gems in production than what you tested with.

--- a/spec/bundler_deploy_spec.rb
+++ b/spec/bundler_deploy_spec.rb
@@ -101,6 +101,25 @@ describe "Deploying an application that uses Bundler" do
       deploy_dir.join('shared', 'bundled_gems', 'RUBY_VERSION').should exist
       deploy_dir.join('shared', 'bundled_gems', 'SYSTEM_VERSION').should exist
     end
+
+    it "warns that using a lockfile is idiomatic" do
+      out = read_output
+      out.should =~ %r(WARNING: Gemfile found but Gemfile.lock is missing!)
+    end
+  end
+
+  context "without a Gemfile.lock and ignoring the warning" do
+    before(:all) do
+      deploy_test_application('no_gemfile_lock', 'config' => {'ignore_gemfile_lock_warning' => true})
+      @config.ignore_gemfile_lock_warning.should be_true
+      @install_bundler_command = @deployer.commands.grep(/gem install bundler/).first
+      @bundle_install_command  = @deployer.commands.grep(/bundle _#{version_pattern}_ install/).first
+    end
+
+    it "should not warn" do
+      out = read_output
+      out.should_not =~ %r(WARNING)
+    end
   end
 
   context "with a failing Gemfile" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -29,6 +29,7 @@ describe EY::Serverside::Deploy::Configuration do
       @config.verbose.should == false
       @config.copy_exclude.should == []
       @config.ignore_database_adapter_warning.should == false
+      @config.ignore_gemfile_lock_warning.should == false
       @config.bundle_without.should == %w[test development]
       @config.extra_bundle_install_options.should == %w[--without test development]
     end


### PR DESCRIPTION
This config option will allow warning-less deploys on Cloud when not
using a version controlled Gemfile.lock

When developing an application on Windows or with multiple ruby engines
you cannot rely on a single Gemfile.lock as it will resolve differently
based on those factors. In these cases you'll want to pessimistically
lock versions in the Gemfile and not version control your Gemfile.lock,
resulting in extra time during deploy to re-resolve the dependencies.
