### PR TITLE
Run `git remote prune origin` before fetching

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## NEXT
 
+  * Run `git remote prune origin` to remove possible branch name collisions before fetching.
   * Update git fetch command to use + for heads and not just tags. "If the optional plus + is used, the local ref is updated even if it does not result in a fast-forward update."
 
 ## v2.3.7 (2013-11-18)


### PR DESCRIPTION
This helps solve branch name collisions that git can't fix during `git fetch`.

This is an alternate solution for #78, as compared to #79, that won't destroy the cache when a git communication failure prevents checkout.
