### PR TITLE
Avoid failing on composer self-update.

### DIFF
--- a/lib/engineyard-serverside/dependency_manager/composer.rb
+++ b/lib/engineyard-serverside/dependency_manager/composer.rb
@@ -48,7 +48,7 @@ To fix this problem, commit your composer.lock to the repository and redeploy.
         end
 
         def composer_selfupdate
-          run "composer self-update"
+          run "command -v composer | xargs -I composer find composer -user #{config.user} -exec {} self-update \\;"
         end
 
         def composer_available?

--- a/spec/multi_dependency_manager_spec.rb
+++ b/spec/multi_dependency_manager_spec.rb
@@ -14,7 +14,7 @@ describe "Deploying an application that uses Node.js and NPM" do
         npm_cmd = @deployer.commands.grep(/npm install/).first
         npm_cmd.should_not be_nil
 
-        update_cmd = @deployer.commands.grep(/composer self-update/).first
+        update_cmd = @deployer.commands.grep(/composer.*self-update/).first
         update_cmd.should_not be_nil
 
         composer_cmd = @deployer.commands.grep(/composer install/).first

--- a/spec/php_deploy_spec.rb
+++ b/spec/php_deploy_spec.rb
@@ -16,10 +16,10 @@ describe "Deploying an application that uses PHP and Composer" do
           install_cmd.should_not be_nil
         end
 
-        it "runs 'composer self-update' before 'composer install'" do
+        it "attempts to run 'composer self-update' before 'composer install'" do
           update_cmd = nil
           @deployer.commands.each do |cmd|
-            update_cmd ||= /composer self-update/.match(cmd)
+            update_cmd ||= /composer.*self-update/.match(cmd)
             if /composer install/.match(cmd)
               update_cmd.should_not be nil
             end
@@ -52,10 +52,10 @@ describe "Deploying an application that uses PHP and Composer" do
           install_cmd.should_not be_nil
         end
 
-        it "runs 'composer self-update' before 'composer install'" do
+        it "attempts to run 'composer self-update' before 'composer install'" do
           update_cmd = nil
           @deployer.commands.each do |cmd|
-            update_cmd ||= /composer self-update/.match(cmd)
+            update_cmd ||= /composer.*self-update/.match(cmd)
             if /composer install/.match(cmd)
               update_cmd.should_not be nil
             end
@@ -66,13 +66,15 @@ describe "Deploying an application that uses PHP and Composer" do
 
     end
 
-    context "without composer available" do
+    unless $COMPOSER_INSTALLED
+      context "without composer available" do
 
-      it "fails to deploy" do
-        expect {deploy_test_application('php_composer_lock')}.to raise_error EY::Serverside::RemoteFailure
-        expect {deploy_test_application('php_no_composer_lock')}.to raise_error EY::Serverside::RemoteFailure
+        it "fails to deploy" do
+          expect {deploy_test_application('php_composer_lock')}.to raise_error EY::Serverside::RemoteFailure
+          expect {deploy_test_application('php_no_composer_lock')}.to raise_error EY::Serverside::RemoteFailure
+        end
+
       end
-
     end
   end
 end


### PR DESCRIPTION
Only run `composer self-update` if the composer binary is owned by the running user. If composer is owned by, say, root and a non-root user runs causes `composer self-update` to be run then the command will fail.
