### PR TITLE
`input_ref` and `deployed_by` config options are real options.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## NEXT
 
   * Update git fetch command to use + for heads and not just tags. "If the optional plus + is used, the local ref is updated even if it does not result in a fast-forward update."
+  * Deploy hook configuration `config.input_ref` and `config.deployed_by` now have defaults and won't NoMethodError when a value isn't set.
 
 ## v2.3.7 (2013-11-18)
 

--- a/lib/engineyard-serverside/configuration.rb
+++ b/lib/engineyard-serverside/configuration.rb
@@ -84,6 +84,8 @@ module EY
       def_option :stack,                  nil
       def_option(:source_class)           { fetch_deprecated(:strategy, :source_class, nil) } # strategy is deprecated
       def_option :branch,                 'master'
+      def_option(:input_ref)              { branch }
+      def_option :deployed_by,            'Automation (User name not available)'
       def_option :current_roles,          []
       def_option :current_name,           nil
       def_option :copy_exclude,           []

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -32,6 +32,8 @@ describe EY::Serverside::Deploy::Configuration do
       @config.ignore_gemfile_lock_warning.should == false
       @config.bundle_without.should == %w[test development]
       @config.extra_bundle_install_options.should == %w[--without test development]
+      @config.deployed_by.should == "Automation (User name not available)"
+      @config.input_ref.should == @config.branch
     end
 
     it "raises when required options are not given" do
@@ -44,9 +46,10 @@ describe EY::Serverside::Deploy::Configuration do
   end
 
   context "strategies" do
-    let(:options) {
+    let(:options) do
       { "app" => "serverside" }
-    }
+    end
+
     it "uses strategy if set" do
       @config = EY::Serverside::Deploy::Configuration.new(
         options.merge({'strategy' => 'IntegrationSpec', 'git' => 'git@github.com:engineyard/todo.git'})
@@ -90,7 +93,7 @@ describe EY::Serverside::Deploy::Configuration do
         'environment_name' => 'env_name',
         'account_name' => 'acc',
         'branch' => 'branch_from_command_line',
-        'config' => MultiJson.dump({'custom' => 'custom_from_extra_config', 'maintenance_on_migrate' => 'false', 'precompile_assets' => 'false'})
+        'config' => MultiJson.dump({'custom' => 'custom_from_extra_config', 'maintenance_on_migrate' => 'false', 'precompile_assets' => 'false', 'deployed_by' => 'Martin Emde', 'input_ref' => 'input_branch'})
       })
     end
 
@@ -112,6 +115,11 @@ describe EY::Serverside::Deploy::Configuration do
 
     it "doesn't bundle --without the framework_env" do
       @config.bundle_without.should == %w[test]
+    end
+
+    it "gets deployed_by and input_ref correct" do
+      @config.deployed_by.should == "Martin Emde"
+      @config.input_ref.should == "input_branch"
     end
   end
 


### PR DESCRIPTION
Previously, these were found via method_missing, which was sloppy
and caused errors when the values weren't available. Giving them
sane defaults will prevent failures when the values aren't set.
