### PR TITLE
fixes cleaning strategy remove_old_assets

### DIFF
--- a/lib/engineyard-serverside/rails_assets/strategy.rb
+++ b/lib/engineyard-serverside/rails_assets/strategy.rb
@@ -139,7 +139,7 @@ module EY
 
             Dir.chdir(shared_assets_path)
 
-            all_assets_on_disk = Dir.glob(shared_assets_path.join('**','*.*').to_s) - [manifest_path.to_s]
+            all_assets_on_disk = Dir.glob(shared_assets_path.join('**','*.*').to_s) - [manifest_path.to_s, shared_assets_path.join('sources_manifest.yml').to_s]
             # $stderr.puts "all_assets_on_disk #{all_assets_on_disk.inspect}"
             assets_on_disk     = all_assets_on_disk.reject {|a| a =~ /\.gz$/}.map {|a| a.sub(shared_assets_path.to_s, '')[1..-1]}
             # $stderr.puts "assets_on_disk #{assets_on_disk.inspect}"


### PR DESCRIPTION
`all_assets_on_disk` comes with full paths while `assets_in_manifest`
have relative path, so alter array subtraction doesn't work as expects.

Another issue is that both sides (keys and values) in manifest required
because keys are plain assets without serialization added. Also values
on the right might be repaeated so I added uniq.
