### PR TITLE
Sets ServerAliveInterval=60 on ssh connections between servers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
   * Run `git remote prune origin` to remove possible branch name collisions before fetching.
   * Update git fetch command to use + for heads and not just tags. "If the optional plus + is used, the local ref is updated even if it does not result in a fast-forward update."
   * Deploy hook configuration `config.input_ref` and `config.deployed_by` now have defaults and won't NoMethodError when a value isn't set.
+  * Sets ServerAliveInterval=60 on ssh connections between servers to avoid timeouts on slow processes (esp. assets).
 
 ## v2.3.7 (2013-11-18)
 

--- a/lib/engineyard-serverside/server.rb
+++ b/lib/engineyard-serverside/server.rb
@@ -82,7 +82,7 @@ module EY
       end
 
       def ssh_command
-        "ssh -i #{ENV['HOME']}/.ssh/internal -o StrictHostKeyChecking=no -o UserKnownHostsFile=#{self.class.known_hosts_file.path} -o PasswordAuthentication=no "
+        "ssh -i #{ENV['HOME']}/.ssh/internal -o StrictHostKeyChecking=no -o UserKnownHostsFile=#{self.class.known_hosts_file.path} -o PasswordAuthentication=no -o ServerAliveInterval=60"
       end
 
     end


### PR DESCRIPTION
Fixes #90

The intention is to avoid timeouts on slow processes that cause
the deploy to appear to fail when it actually succeeds.
