### PR TITLE
Add ruby 2.1.2 as a build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.2
 notifications:
   recipients:
     - memde@engineyard.com


### PR DESCRIPTION
Build on travis using ruby 2.1.2 to make sure everything still works ok.
