### PR TITLE
Do not remove `public/system` from the repository when it exists.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-  *
+  * Do not remove `public/system` from the repository when it exists. Warn that maintenance pages may not work.
 
 ## v2.3.9 (2014-03-26)
 
@@ -42,7 +42,7 @@
 
 ## v2.3.2 (2013-10-09)
 
-  * Add hooks `before_deploy` and `after_deploy` that happen near the beginning (after release directory is created) and at the end of the deploy task. 
+  * Add hooks `before_deploy` and `after_deploy` that happen near the beginning (after release directory is created) and at the end of the deploy task.
   * Support option --clean which will force gems to be reinstalled (eg. when making a server architecture change that isn't already caught)
   * If dependncy manager options are set to blank, treat it like "detect".
   * Fix an issue with integrate action.

--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -337,12 +337,13 @@ YML
       def symlink_tasks
         [
           ["Set group write permissions",           "chmod -R g+w #{paths.active_release}"],
-          ["Remove symlinked shared directories",   "rm -rf #{paths.active_log} #{paths.public_system} #{paths.active_release}/tmp/pids"],
+          ["Remove public/system if symlinked",     "if [ -L \"#{paths.public_system}\" ]; then rm -rf #{paths.public_system}; fi"],
+          ["Remove symlinked shared directories",   "rm -rf #{paths.active_log} #{paths.active_release}/tmp/pids"],
           ["Create tmp directory",                  "mkdir -p #{paths.active_release}/tmp"],
           ["Create public directory",               "mkdir -p #{paths.public}"],
           ["Create config directory",               "mkdir -p #{paths.active_release_config}"],
           ["Symlink shared log directory",          "ln -nfs #{paths.shared_log} #{paths.active_log}"],
-          ["Symlink public system directory",       "ln -nfs #{paths.shared_system} #{paths.public_system}"],
+          ["Symlink public system directory",       "if [ ! -e \"#{paths.public_system}\" ]; then ln -ns #{paths.shared_system} #{paths.public_system}; fi"],
           ["Symlink shared pids directory",         "ln -nfs #{paths.shared}/pids #{paths.active_release}/tmp/pids"],
           ["Symlink other shared config files",     "find #{paths.shared_config} -maxdepth 1 -type f -not -name 'database.yml' -exec ln -s {} #{paths.active_release_config} \\;"],
           ["Symlink database.yml if needed",        "if [ -f \"#{paths.shared_config}/database.yml\" ]; then ln -nfs #{paths.shared_config}/database.yml #{paths.active_release_config}/database.yml; fi"],

--- a/lib/engineyard-serverside/maintenance.rb
+++ b/lib/engineyard-serverside/maintenance.rb
@@ -58,8 +58,9 @@ module EY
 
       def enable
         shell.status "Enabling maintenance page."
-        @up = true
         run "mkdir -p #{maintenance_page_dirname}"
+        public_system_symlink_warning
+        @up = true
         run "cp #{source_path} #{enabled_maintenance_page_pathname}"
       end
 
@@ -107,6 +108,18 @@ This application stack does not support no-downtime restarts.
         end
       end
 
+      def public_system_symlink_warning
+        if paths.public_system.realpath != maintenance_page_dirname.realpath
+          shell.warning <<-WARN
+Current repository layout does not allow for maintenance pages!
+Web traffic may still be served to your application.
+
+Expected a symlink at #{paths.public_system}
+
+To use maintenance pages, remove 'public/system' from your repository.
+          WARN
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/repos/public_system/Gemfile
+++ b/spec/fixtures/repos/public_system/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'ey_config'

--- a/spec/fixtures/repos/public_system/Gemfile.lock
+++ b/spec/fixtures/repos/public_system/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ey_config (0.0.5)
+    rake (0.9.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ey_config
+  rake

--- a/spec/fixtures/repos/public_system/README
+++ b/spec/fixtures/repos/public_system/README
@@ -1,0 +1,5 @@
+This is a simple bundled fake app for specs.
+
+All the files in this directory are copied into a temporary git repository
+during spec runs. The rest of the "git repository" stuff comes from
+gitrepo.tar.gz which is copied first to create the repo.

--- a/spec/fixtures/repos/public_system/ey.yml
+++ b/spec/fixtures/repos/public_system/ey.yml
@@ -1,0 +1,3 @@
+environments:
+  env:
+    ignore_database_adapter_warning: true

--- a/spec/fixtures/repos/public_system/public/system/cant_touch_this.txt
+++ b/spec/fixtures/repos/public_system/public/system/cant_touch_this.txt
@@ -1,0 +1,3 @@
+This file should not be removed by serverside during a deploy.
+
+If public/system exists in the repository, leave it alone and warn.

--- a/spec/symlink_spec.rb
+++ b/spec/symlink_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe "Deploying an application with conflicting directories" do
+  before(:all) do
+    deploy_test_application('public_system')
+  end
+
+  it "does not remove the repository's public/system directory" do
+    expect(deploy_dir.join('current', 'public', 'system', 'cant_touch_this.txt')).to exist
+  end
+
+  it "warns that maintenance pages are broken" do
+    expect(read_output).to include("remove 'public/system' from your repository")
+  end
+end


### PR DESCRIPTION
Warn that maintenance pages may not work.
