### PR TITLE
Execute non-Ruby hooks.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## NEXT
 
   * Do not remove `public/system` from the repository when it exists. Warn that maintenance pages may not work.
+  * Add support for non-Ruby deploy hooks. These have the same names/locations as the ruby hooks but without the '.rb' suffix (e.g. deploy/before_symlink).
 
 ## v2.3.9 (2014-03-26)
 

--- a/bin/engineyard-serverside-execute-hook
+++ b/bin/engineyard-serverside-execute-hook
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#
+# This script is used to execute non-ruby deploy hooks. It's called from
+# EY::Serverside::Deploy#callback. If you'd like to call it directly you should
+# be careful to replicate everything done in EY::Serverside::Deploy or your
+# hook code may not execute as planned.
+#
+
+set -o nounset
+
+abort() {
+  echo "$*"
+  exit 1
+}
+
+HOOK=${1:-}
+[ -n "${HOOK}" ] || abort "No hook name provided."
+
+# We run all deploy hooks from the root directory of the current release of
+# their app.
+[ -n "${EY_DEPLOY_RELEASE_PATH:-}" ] || abort "EY_DEPLOY_RELEASE_PATH must be set."
+[ -d ${EY_DEPLOY_RELEASE_PATH} ] || abort "EY_DEPLOY_RELEASE_PATH must exist and be a directory"
+cd ${EY_DEPLOY_RELEASE_PATH}
+
+# Run the hook.
+_hook_path=deploy/${HOOK}
+if [ ! \( -f ${_hook_path} -a -x ${_hook_path} \) ]; then
+  abort "${_hook_path} must exist and be executable"
+fi
+exec ${_hook_path}

--- a/lib/engineyard-serverside/about.rb
+++ b/lib/engineyard-serverside/about.rb
@@ -32,6 +32,9 @@ module EY
         File.expand_path("../../../bin/#{gem_name}", __FILE__)
       end
 
+      def hook_executor
+        binary + "-execute-hook"
+      end
     end
   end
 end

--- a/lib/engineyard-serverside/paths.rb
+++ b/lib/engineyard-serverside/paths.rb
@@ -108,6 +108,10 @@ module EY
         path(:active_release, 'deploy', "#{hook_name}.rb")
       end
 
+      def executable_deploy_hook(hook_name)
+        path(:active_release, 'deploy', "#{hook_name}")
+      end
+
       def repository_cache
         @repository_cache ||= default_repository_cache
       end

--- a/spec/deploy_hook_spec.rb
+++ b/spec/deploy_hook_spec.rb
@@ -43,6 +43,16 @@ describe "deploy hooks" do
     end
   end
 
+  context "with an executable for a deploy hook" do
+    before(:all) do
+      deploy_test_application('executable_hooks')
+    end
+
+    it 'runs the hook' do
+      deploy_dir.join('current', 'before_restart.ran').should exist
+    end
+  end
+
   context "deploy hook API" do
 
     def deploy_hook(options={})

--- a/spec/fixtures/repos/executable_hooks/README
+++ b/spec/fixtures/repos/executable_hooks/README
@@ -1,0 +1,1 @@
+Use an executable file for a hook, not a ruby one that uses the hook API.

--- a/spec/fixtures/repos/executable_hooks/deploy/before_restart
+++ b/spec/fixtures/repos/executable_hooks/deploy/before_restart
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+_TEST_NUMBER=1
+_FAILED=0
+
+run_tests() {
+  local _env_var
+
+  expect_env EY_DEPLOY_ACCOUNT_NAME acc
+  expect_env EY_DEPLOY_APP rails31
+  expect_env EY_DEPLOY_ENVIRONMENT_NAME env
+  expect_env EY_DEPLOY_FRAMEWORK_ENV staging
+  expect_env MERB_ENV staging
+  expect_env NODE_ENV staging
+  expect_env RACK_ENV staging
+  expect_env RAILS_ENV staging
+  for _env_var in EY_DEPLOY_CONFIG EY_DEPLOY_RELEASE_PATH EY_DEPLOY_VERBOSE; do
+    expect_env ${_env_var}
+  done
+
+  check_working_directory ${EY_DEPLOY_RELEASE_PATH}
+}
+
+ok() {
+  echo "ok ${_TEST_NUMBER} $*"
+  _TEST_NUMBER=$((${_TEST_NUMBER} + 1))
+}
+
+not_ok() {
+  echo "not ok ${_TEST_NUMBER} $*"
+  _FAILED=1
+  _TEST_NUMBER=$((${_TEST_NUMBER} + 1))
+}
+
+check_working_directory() {
+  local _dir=$1
+
+  if [ $(pwd) = ${_dir} ]; then
+    ok "Working directory is correct"
+  else
+    not_ok "Working directory is correct"
+  fi
+}
+
+expect_env() {
+  local _name=$1
+  local _value=${2:-}
+  local _var
+  local _test_name
+
+  _test_name="ENV[${_name}]"
+  if [ -n "${_value}" ]; then
+    _test_name="${_test_name}=${_value}"
+  else
+    _test_name="${_test_name} should be set"
+  fi
+
+  eval "_var=\$${_name}"
+  if [ -n "${_var}" ]; then
+    if [ -n "${_value}" -a "${_var}" != "${_value}" ]; then
+      not_ok ${_test_name}
+    else
+      ok ${_test_name}
+    fi
+  else
+    not_ok ${_test_name}
+  fi
+}
+
+run_tests
+touch 'before_restart.ran'
+exit ${_FAILED}


### PR DESCRIPTION
If `deploy/x.rb` does not exist and if `deploy/x` does exist AND is executable then `deploy/x` is executed.

This does not add any extra hook points. The user may mix and match ruby and executable hooks _but_ only one hook script will be executed per hook point and the Ruby one has precedence.

There are several environment variables made available to the hook programs and they are as follows:
- `EY_DEPLOY_ACCOUNT_NAME` - The name of the account which owns the app.
- `EY_DEPLOY_APP` - The application's name
- `EY_DEPLOY_CONFIG` - A JSON blob containing the deploy configuration information.
- `EY_DEPLOY_CURRENT_NAME` - If the server is a utility instance, this is the name of the server. It's unset for all other server types.
- `EY_DEPLOY_CURRENT_ROLES` - The roles of the server the hook is being run on.
- `EY_DEPLOY_ENVIRONMENT_NAME` - The name of the environment in which the app is running.
- `EY_DEPLOY_FRAMEWORK_ENV` - The value for `RAILS_ENV` et al. This is copied into `RAILS_ENV`, `RACK_ENV`, `NODE_ENV` and `MERB_ENV`.
- `EY_DEPLOY_RELEASE_PATH` - The full path to the directory containing the release of the application which is being deployed.
- `EY_DEPLOY_VERBOSE` - `1` if the deploy is being done with verbose logging, `0` otherwise.
