### PR TITLE
raise when waitpid2 returns non-nil that isn't a pid

### DIFF
--- a/lib/engineyard-serverside/spawner.rb
+++ b/lib/engineyard-serverside/spawner.rb
@@ -77,8 +77,12 @@ module EY
             elsif child = @child_by_pid.delete(pid)
               child.finished status
               just_reaped << child
+            elsif pid == -1
+              # waitpid encountered an error (as defined in linux waitpid manpage)
+              # apparently it can leak through ruby's waitpid abstraction
+              raise "Fatal error encountered while waiting for a child process to exit. waitpid2 returned: [#{pid.inpsect}, #{status.inspect}].\nExpected one of children: #{@child_by_pid.keys.inspect}"
             else
-              raise "Unknown pid returned from Process::waitpid2 => #{pid.inpsect}, #{status.inspect}. Expected children: #{@child_by_pid.keys.inspect}"
+              raise "Unknown pid returned from waitpid2 => #{pid.inpsect}, #{status.inspect}.\nExpected one of children: #{@child_by_pid.keys.inspect}"
             end
           rescue Errno::ECHILD
             possible_children = false


### PR DESCRIPTION
It doesn't seem like this should happen.
I can't reproduce it locally, nor can I find documentation showing
any other response other than a pid in ruby or unix/linux docs.
Nevertheless, it is occurring on at least one customer instance,
so hopefully the error output here will help us track it down.
