### PR TITLE
[git wrapper] defend against helpful git

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -177,7 +177,10 @@ mkdir -p #{path.dirname}
 [ -x #{path} ] || cat > #{path} <<'SSH'
 #!/bin/sh
 unset SSH_AUTH_SOCK
-ssh -o CheckHostIP=no -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o LogLevel=INFO -o IdentityFile=#{paths.deploy_key} -o IdentitiesOnly=yes $*
+
+# Filter command mangling by git when using `GIT_SSH` and the string `plink`
+command=$(echo "$*" | sed -e "s/^-batch //")
+ssh -o CheckHostIP=no -o StrictHostKeyChecking=no -o PasswordAuthentication=no -o LogLevel=INFO -o IdentityFile=#{paths.deploy_key} -o IdentitiesOnly=yes ${command}
 SSH
 chmod 0700 #{path}
         SCRIPT


### PR DESCRIPTION
When using `GIT_SSH`, git attempts to detect accommodate the use of
`Plink.exe` by simply matching against `plink`. If detected, git adds
`-batch` to the command invocation which breaks our wrapper scripts.

Filter this specific case. Ref: Triage-5683, US729
