### PR TITLE
Support experimental ey.yml options `keep_releases` & `keep_failed_releases`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-  *
+  * Supports `ey.yml` option `keep_releases` and `keep_failed_releases` for how many releases to keep in the `releases` dir (default: 3)
 
 ## v2.4.1 (2014-06-25)
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ A typical application will not need most of these options.
       asset_roles: :all                         # specify on which roles to compile assets (default: [:app, :app_master, :solo])
       ignore_database_adapter_warning: true     # hide database adapter warning if you don't use MySQL or PostgreSQL (default: false)
       ignore_gemfile_lock_warning: true         # hide warning when Gemfile is present but Gemfile.lock is missing. (default: false)
+      keep_releases: 3                          # keep more or less releases (default: 3; Recommended: >= 2; MUST BE >= 1, with 1 being experimental)
+      keep_failed_releases: 3                   # keep more or less failed releases (default: 3)
       gc: false                                 # if true, run repository garbage collection every deploy. (default: git will run gc as needed)
 
     # Environment specific options apply only to a single environment and override settings in defaults.

--- a/lib/engineyard-serverside/configuration.rb
+++ b/lib/engineyard-serverside/configuration.rb
@@ -103,6 +103,11 @@ module EY
 
       def_option :restart_groups,         1
 
+      DEFAULT_KEEP_RELEASES = 3
+
+      def_option :keep_releases,          DEFAULT_KEEP_RELEASES
+      def_option :keep_failed_releases,   DEFAULT_KEEP_RELEASES
+
       def_boolean_option :clean,                           false
       def_boolean_option :verbose,                         false
       def_boolean_option :gc,                              false

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -34,6 +34,8 @@ describe EY::Serverside::Deploy::Configuration do
       expect(@config.extra_bundle_install_options).to eq(%w[--without test development])
       expect(@config.deployed_by).to eq("Automation (User name not available)")
       expect(@config.input_ref).to eq(@config.branch)
+      expect(@config.keep_releases).to eq(3)
+      expect(@config.keep_failed_releases).to eq(3)
     end
 
     it "raises when required options are not given" do


### PR DESCRIPTION
Changes the number of releases or failed releases that will be kept
after the deploy has finished.
