### PR TITLE
Warn if we skip a non-executable "executable" hook.

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -402,6 +402,8 @@ YML
               "#{k}=#{Escape.shell_command([v])}"
             }.join(' ') + ' ' + config.framework_envs + ' ' + cmd
           end
+        elsif paths.executable_deploy_hook(what).exist?
+          shell.status "Skipping possible deploy hook deploy/#{what} because it's not executable."
         end
       end
 

--- a/spec/deploy_hook_spec.rb
+++ b/spec/deploy_hook_spec.rb
@@ -53,6 +53,20 @@ describe "deploy hooks" do
     end
   end
 
+  context "with a non-executable, but correctly named deploy hook" do
+    before(:all) do
+      deploy_test_application('executable_hooks_not_executable')
+    end
+
+    it 'does not run the hook' do
+      deploy_dir.join('current', 'before_restart.ran').should_not exist
+    end
+
+    it 'outputs a message about the hook not being executable' do
+      expect(read_output).to match(%r|Skipping.*deploy hook.*not executable|)
+    end
+  end
+
   context "deploy hook API" do
 
     def deploy_hook(options={})

--- a/spec/fixtures/repos/executable_hooks_not_executable/README
+++ b/spec/fixtures/repos/executable_hooks_not_executable/README
@@ -1,0 +1,3 @@
+Use an executable file for a hook, not a ruby one that uses the hook API.
+
+Except that the file is not actually executable, so it should not be run.

--- a/spec/fixtures/repos/executable_hooks_not_executable/deploy/before_restart
+++ b/spec/fixtures/repos/executable_hooks_not_executable/deploy/before_restart
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+touch 'before_restart.ran'


### PR DESCRIPTION
We only execute hooks if they have both the correct name and are
executable. If there's a file that has a hook-like name but is not
executable we still don't run it, but now we output a message so that
it's more obvious why it has not been executed.
