### PR TITLE
Maintenance still up notice => status for visibility without stickiness

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## NEXT
 
+  * "Maintenance page still up" notices will be shown as status messages in the deploy log to prevent sticky notices on the dashboard that are not relevant.
   * Fixes release cleanup for `before_deploy` hook failures. Previously, hook failures would not trigger the cleanup of the release directory.
   * Supports `ey.yml` option `keep_releases` and `keep_failed_releases` for how many releases to keep in the `releases` dir (default: 3)
   * Warn when a file that looks like an executable deploy hook is skipped because it is not executable.

--- a/lib/engineyard-serverside/maintenance.rb
+++ b/lib/engineyard-serverside/maintenance.rb
@@ -44,7 +44,7 @@ module EY
         if using_maintenance_page?
           disable
         elsif exist?
-          shell.notice "[Attention] Maintenance page is still up.\nYou must remove it manually using `ey web enable`."
+          shell.status "[Attention] Maintenance page is still up.\nYou must remove it manually using `ey web enable`."
         end
       end
 


### PR DESCRIPTION
It's confusing when the maintenance page still up notice is posted on
the dashboard and sticks around after the maintenance page has been
taken down. The work has already been done in the dashboard to treat
maintenance requests as first class citizens, so this could be solved in
a better way soon.
