### PR TITLE
Add new ey.yml option `precompile_assets_command`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,9 @@
 
 ## NEXT
 
-  *
+  * Add new ey.yml option `precompile_assets_command`
+    Setting `precompile_assets_command` overrides the asset precompile rake command. (default: `rake assets:precompile RAILS_GROUPS=assets`)
+    Bundler binstubs are in PATH so gem binaries will load through bundler.
 
 ## v2.5.0 (2014-09-23)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A typical application will not need most of these options.
       maintenance_on_migrate: true              # show maintenance page during migrations (default: true)
       precompile_assets: true                   # ensure rails assets precompilation (default: assets will be compiled if they are detected)
       precomplie_assets_task: assets:precompile # override the assets:precompile rake task
+      precompile_assets_command: rake assets:precompile # override the entire precompile command (ignores precompile_assets_task)
       precompile_unchanged_assets: false        # if true, does not check git for changes before precompiling assets.
       asset_dependencies:                       # a list of relative paths to search for asset changes during each deploy.
       - app/assets                              # default

--- a/lib/engineyard-serverside/configuration.rb
+++ b/lib/engineyard-serverside/configuration.rb
@@ -77,6 +77,7 @@ module EY
 
       def_option :precompile_assets,      'detect'
       def_option :precompile_assets_task, 'assets:precompile'
+      def_option(:precompile_assets_command) { "rake #{precompile_assets_task} RAILS_GROUPS=assets" }
       def_option :asset_strategy,         'shifting'
       def_option :asset_dependencies,     %w[app/assets lib/assets vendor/assets Gemfile.lock config/routes.rb config/application.rb]
       def_option :asset_roles,            [:app_master, :app, :solo]

--- a/lib/engineyard-serverside/rails_assets.rb
+++ b/lib/engineyard-serverside/rails_assets.rb
@@ -19,7 +19,8 @@ module EY
       def_delegators :config,
         :paths, :asset_dependencies, :asset_roles,
         :framework_envs, :precompile_assets?, :skip_precompile_assets?,
-        :precompile_unchanged_assets?, :precompile_assets_task
+        :precompile_unchanged_assets?, :precompile_assets_task,
+        :precompile_assets_command
 
       def detect_and_compile
         runner.roles asset_roles do
@@ -52,7 +53,7 @@ module EY
       def run_precompile_assets_task
         asset_strategy.prepare do
           cd   = "cd #{paths.active_release}"
-          task = "PATH=#{paths.binstubs}:$PATH #{framework_envs} rake #{precompile_assets_task} RAILS_GROUPS=assets"
+          task = "PATH=#{paths.binstubs}:$PATH #{framework_envs} #{precompile_assets_command}"
           runner.run "#{cd} && #{task}"
         end
       end

--- a/spec/fixtures/repos/assets_enabled_all/config/ey.yml
+++ b/spec/fixtures/repos/assets_enabled_all/config/ey.yml
@@ -2,4 +2,5 @@ environments:
   env:
     precompile_assets: true
     asset_roles: :all
+    precompile_assets_command: touch custom_compiled
     ignore_database_adapter_warning: true

--- a/spec/rails31_deploy_spec.rb
+++ b/spec/rails31_deploy_spec.rb
@@ -97,13 +97,13 @@ describe "Deploying a Rails 3.1 application" do
     end
   end
 
-  context "with asset compilation enabled in ey.yml, and asset_roles is set to :all" do
+  context "with asset compilation enabled in ey.yml, and asset_roles is set to :all, and a custom compile command" do
     before(:all) do
       deploy_test_application('assets_enabled_all')
     end
 
     it "precompiles assets" do
-      expect(deploy_dir.join('current', 'precompiled')).to exist
+      expect(deploy_dir.join('current', 'custom_compiled')).to exist
       expect(read_output).to include("Precompiling assets. (precompile_assets: true)")
     end
   end


### PR DESCRIPTION
Setting `precompile_assets_command` overrides the asset precompile rake
command. Currently the default is:

`rake assets:precompile RAILS_GROUPS=assets`

Bundler binstubs are in PATH so gem binaries will load through bundler.
