### PR TITLE
add maintenance status

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-  *
+  * Add `maintenance_status` option to the CLI that outputs "Maintenance status: down" or "Maintenance status: up" if the maintenance page is on the server
 
 ## v2.4.2 (2014-07-30)
 

--- a/engineyard-serverside.gemspec
+++ b/engineyard-serverside.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('timecop', '0.6.1')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('engineyard-cloud-client', '~>1.0.14')
-  s.add_development_dependency('engineyard-serverside-adapter', '~>2.3.1')
+  s.add_development_dependency('engineyard-serverside-adapter', '~>2.4.0')
   s.add_development_dependency('sqlite3')
   s.add_development_dependency('mime-types', '~>1.25')
 

--- a/lib/engineyard-serverside/cli.rb
+++ b/lib/engineyard-serverside/cli.rb
@@ -66,6 +66,17 @@ module EY
       config_option
       instances_options
       verbose_option
+      desc "maintenance_status", "Maintenance status"
+      def maintenance_status
+        init(options, "maintenance-status") do |servers, config, shell|
+          EY::Serverside::Maintenance.new(servers, config, shell).status
+        end
+      end
+
+      account_app_env_options
+      config_option
+      instances_options
+      verbose_option
       desc "disable_maintenance", "Disable maintenance page (enables web access)"
       def disable_maintenance
         init_and_propagate(options, 'disable_maintenance') do |servers, config, shell|

--- a/lib/engineyard-serverside/maintenance.rb
+++ b/lib/engineyard-serverside/maintenance.rb
@@ -16,6 +16,15 @@ module EY
         @up
       end
 
+      def status
+        if exist?
+          shell.info "Maintenance page: up"
+        else
+          shell.info "Maintenance page: down"
+        end
+        exist?
+      end
+
       def manually_enable
         if paths.deployed?
           enable

--- a/lib/engineyard-serverside/version.rb
+++ b/lib/engineyard-serverside/version.rb
@@ -1,5 +1,5 @@
 module EY
   module Serverside
-    VERSION = '2.4.3.pre'
+    VERSION = '2.5.0.pre'
   end
 end

--- a/spec/maintenance_spec.rb
+++ b/spec/maintenance_spec.rb
@@ -19,5 +19,26 @@ describe EY::Serverside::Maintenance do
       disable_maintenance
       expect(maintenance_path).to_not exist
     end
+
+    it "lets you know if the app is in maintenance mode" do
+      maintenance_status
+      maintenance_output = read_output.split("\n").select{|l| l.match("Maintenance")}
+      maintenance_output.count.should == 1
+      maintenance_output.first.should match(/Maintenance page: down$/)
+
+      enable_maintenance
+
+      maintenance_status
+      maintenance_output = read_output.split("\n").select{|l| l.match("Maintenance")}
+      maintenance_output.count.should == 1
+      maintenance_output.first.should match(/Maintenance page: up$/)
+
+      disable_maintenance
+
+      maintenance_status
+      maintenance_output = read_output.split("\n").select{|l| l.match("Maintenance")}
+      maintenance_output.count.should == 1
+      maintenance_output.first.should match(/Maintenance page: down$/)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -237,7 +237,7 @@ exec "$@"
     }
   end
 
-  def test_adapter(repo_fixture_name = 'default', extra_config = {}, &block)
+  def test_adapter(repo_fixture_name = 'default', extra_config = {})
     options = default_configuration.merge({ "git" => FIXTURES_DIR.join('repos', repo_fixture_name)}).merge(extra_config)
 
     # pretend there is a shared bundled_gems directory
@@ -273,7 +273,7 @@ exec "$@"
   # spec/fixtures/repos dir are copied into the test github repository.
   def deploy_test_application(repo_fixture_name = 'default', extra_config = {}, &block)
     Timecop.travel(1)
-    @adapter = test_adapter(repo_fixture_name, extra_config, &block)
+    @adapter = test_adapter(repo_fixture_name, extra_config)
     @argv = @adapter.deploy.commands.last.to_argv[2..-1]
 
     FullTestDeploy.on_create_callback = block
@@ -320,8 +320,8 @@ exec "$@"
     @config = EY::Serverside::Deploy.config
   end
 
-  def enable_maintenance(extra_config = {}, &block)
-    @adapter = test_adapter("default", extra_config, &block)
+  def enable_maintenance(extra_adapter_config = {})
+    @adapter = test_adapter("default", extra_adapter_config)
     @argv = @adapter.enable_maintenance.commands.last.to_argv[2..-1]
 
     with_mocked_commands do
@@ -331,8 +331,8 @@ exec "$@"
     end
   end
 
-  def disable_maintenance(extra_config = {}, &block)
-    @adapter = test_adapter("default", extra_config, &block)
+  def disable_maintenance(extra_adapter_config = {})
+    @adapter = test_adapter("default", extra_adapter_config)
     @argv = @adapter.disable_maintenance.commands.last.to_argv[2..-1]
 
     with_mocked_commands do
@@ -342,4 +342,14 @@ exec "$@"
     end
   end
 
+  def maintenance_status(extra_adapter_config = {})
+    @adapter = test_adapter("default", extra_adapter_config)
+    @argv = @adapter.maintenance_status.commands.last.to_argv[2..-1]
+
+    with_mocked_commands do
+      capture do
+        EY::Serverside::CLI.start(@argv)
+      end
+    end
+  end
 end


### PR DESCRIPTION
maintenance_status action returns true or false as well as outputting
"Maintenance page: up" or "Maintenance page: down"
update version to 2.5.0.pre for compatibility with next version of the
adapter
