### PR TITLE
Speed up assets in Rails by sharing tmp directory between deploys

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
   * Add new ey.yml option `precompile_assets_command`
     Setting `precompile_assets_command` overrides the asset precompile rake command. (default: `rake assets:precompile RAILS_GROUPS=assets`)
     Bundler binstubs are in PATH so gem binaries will load through bundler.
+  * In order to speed up asset compilation in Rails, the directory `/data/app/current/tmp` is now preserved between deploys to maintain assets cache.
+    To disable this feature, set `shared_tmp: false` in `ey.yml`.
 
 ## v2.5.0 (2014-09-23)
 

--- a/lib/engineyard-serverside/configuration.rb
+++ b/lib/engineyard-serverside/configuration.rb
@@ -115,6 +115,7 @@ module EY
       def_boolean_option :precompile_unchanged_assets,     false
       def_boolean_option :ignore_database_adapter_warning, false
       def_boolean_option :ignore_gemfile_lock_warning,     false
+      def_boolean_option :shared_tmp,                      true
       def_boolean_option :eydeploy_rb,                     true
       def_boolean_option :maintenance_on_migrate,          true
       def_boolean_option(:maintenance_on_restart)          { required_downtime_stack? }

--- a/lib/engineyard-serverside/paths.rb
+++ b/lib/engineyard-serverside/paths.rb
@@ -64,6 +64,7 @@ module EY
       def_path :releases_failed,          [:deploy_root,    'releases_failed']
       def_path :shared,                   [:deploy_root,    'shared']
       def_path :shared_log,               [:shared,         'log']
+      def_path :shared_tmp,               [:shared,         'tmp']
       def_path :shared_config,            [:shared,         'config']
       def_path :shared_system,            [:shared,         'system']
       def_path :default_repository_cache, [:shared,         'cached-copy']
@@ -86,6 +87,7 @@ module EY
       def_path :composer_lock,            [:active_release, 'composer.lock']
       def_path :active_release_config,    [:active_release, 'config']
       def_path :active_log,               [:active_release, 'log']
+      def_path :active_tmp,               [:active_release, 'tmp']
 
       def initialize(opts)
         @opts             = opts

--- a/spec/fixtures/repos/assets_enabled_all/Rakefile
+++ b/spec/fixtures/repos/assets_enabled_all/Rakefile
@@ -1,6 +1,0 @@
-desc 'Precompile yar assetz'
-task 'assets:precompile' do
-  sh "touch #{File.expand_path('../public/assets/compiled_asset', __FILE__)}"
-  sh 'touch precompiled'
-end
-

--- a/spec/fixtures/repos/assets_enabled_all/config/ey.yml
+++ b/spec/fixtures/repos/assets_enabled_all/config/ey.yml
@@ -2,5 +2,5 @@ environments:
   env:
     precompile_assets: true
     asset_roles: :all
-    precompile_assets_command: touch custom_compiled
+    precompile_assets_command: script/assets
     ignore_database_adapter_warning: true

--- a/spec/fixtures/repos/assets_enabled_all/script/assets
+++ b/spec/fixtures/repos/assets_enabled_all/script/assets
@@ -1,0 +1,5 @@
+#!/bin/sh
+touch public/assets/custom_compiled_asset
+touch custom_compiled
+# mirror the behavior of compiling using asset caches in tmp
+[ -e tmp/cache ] && touch cache_compiled || touch tmp/cache

--- a/spec/fixtures/repos/assets_enabled_all/tmp/obstruction
+++ b/spec/fixtures/repos/assets_enabled_all/tmp/obstruction
@@ -1,0 +1,1 @@
+This file obstructs the sharing of the tmp dir.

--- a/spec/fixtures/repos/assets_enabled_in_ey_yml/Rakefile
+++ b/spec/fixtures/repos/assets_enabled_in_ey_yml/Rakefile
@@ -3,5 +3,6 @@ task 'assets:precompile' do
   sh "mkdir -p #{File.expand_path('../public/assets', __FILE__)}"
   sh "touch #{File.expand_path('../public/assets/compiled_asset', __FILE__)}"
   sh 'touch precompiled'
+  sh '[ -e tmp/cache ] && touch cache_compiled || touch tmp/cache' # mirror the behavior of compiling using asset caches in tmp
 end
 


### PR DESCRIPTION
The directory `/data/app/current/tmp` is now a symlink to `/data/app/shared/tmp`
