### PR TITLE
Reduce ruby object allocation by 3x

### DIFF
--- a/lib/engineyard-serverside/cli.rb
+++ b/lib/engineyard-serverside/cli.rb
@@ -181,10 +181,10 @@ module EY
         begin
           yield servers, config, shell
         rescue EY::Serverside::RemoteFailure => e
-          shell.exception "#{e.message}"
+          shell.fatal e.message
           raise
         rescue Exception => e
-          shell.exception "#{e.backtrace[0]}: #{e.message} (#{e.class})"
+          shell.fatal "#{e.backtrace[0]}: #{e.message} (#{e.class})"
           raise
         end
       end

--- a/lib/engineyard-serverside/configuration.rb
+++ b/lib/engineyard-serverside/configuration.rb
@@ -298,8 +298,8 @@ module EY
       # The nodatabase.yml file is dropped by server configuration when there is
       # no database in the cluster.
       def has_database?
-        paths.shared_config.join('database.yml').exist? &&
-          !paths.shared_config.join('nodatabase.yml').exist?
+        paths.path(:shared_config, 'database.yml').exist? &&
+          !paths.path(:shared_config, 'nodatabase.yml').exist?
       end
 
       def check_database_adapter?

--- a/lib/engineyard-serverside/rails_assets.rb
+++ b/lib/engineyard-serverside/rails_assets.rb
@@ -140,11 +140,11 @@ ACTION REQUIRED: Add precompile_assets option to ey.yml.
       end
 
       def application_rb_path
-        paths.active_release.join('config','application.rb')
+        paths.path(:active_release,'config','application.rb')
       end
 
       def app_assets_path
-        paths.active_release.join('app', 'assets')
+        paths.path(:active_release,'app','assets')
       end
 
       def asset_strategy

--- a/lib/engineyard-serverside/rails_assets/strategy.rb
+++ b/lib/engineyard-serverside/rails_assets/strategy.rb
@@ -48,7 +48,7 @@ module EY
           #   deploy_root/current/public/last_assets/assets -> deploy_root/releases/<prev>/public/assets
           def prepare
             if previous_assets_path
-              last = paths.public.join('last_assets')
+              last = paths.path(:public,'last_assets')
               run "mkdir -p #{last} && ln -nfs #{previous_assets_path} #{last.join('assets')}"
             end
 

--- a/spec/shell_spec.rb
+++ b/spec/shell_spec.rb
@@ -35,24 +35,23 @@ describe EY::Serverside::Shell do
     tstp_1 = "+    00s "
     tstp_2 = "+ 3m 05s "
     tstp_3 = "+10m 25s "
-    notstp = "         "
     output.rewind
     expect(output.read).to eq <<-OUTPUT
-#{notstp} debug
+#{tstp_1} debug
 
 \e[1m\e[33m#{tstp_1} !> notice
 \e[0m
 \e[1m\e[37m#{tstp_2} ~> STATUS
-\e[0m#{notstp} multi
-#{notstp} line
-#{notstp} debug
+\e[0m#{tstp_2} multi
+#{tstp_2} line
+#{tstp_2} debug
 
 \e[1m\e[33m#{tstp_2} !> WARNING: multi
 #{tstp_2} !> line
 #{tstp_2} !> warning
-\e[0m#{notstp}  ~ multi
-#{notstp}  ~ line
-#{notstp}  ~ substatus
+\e[0m#{tstp_3}  ~ multi
+#{tstp_3}  ~ line
+#{tstp_3}  ~ substatus
     OUTPUT
   end
 end


### PR DESCRIPTION
Also starts displaying timestamps on most lines because it saves a few
objects (and uses objects that are already created and are useful)

Running the first spec in rails31_deploy_spec.rb and watching memory
allocation from CLI.start.

On master:

```
Total allocated 17185
Total retained 269

allocated memory by gem
-----------------------------------
2.1.2/lib x 718600
engineyard-serverside/lib x 701369
other x 23225
rubygems x 658

allocated objects by gem
-----------------------------------
2.1.2/lib x 12344
engineyard-serverside/lib x 4320
other x 511
rubygems x 10
```

With these changes:

```
Total allocated 5684
Total retained 274

allocated memory by gem
-----------------------------------
engineyard-serverside/lib x 714169
2.1.2/lib x 103434
other x 23063
rubygems x 658

allocated objects by gem
-----------------------------------
engineyard-serverside/lib x 4160
2.1.2/lib x 1007
other x 507
rubygems x 10
```
