### PR TITLE
Test and integrate a custom nginx.conf if provided.

### DIFF
--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -5,6 +5,7 @@ require 'engineyard-serverside/rails_assets'
 require 'engineyard-serverside/maintenance'
 require 'engineyard-serverside/dependency_manager'
 require 'engineyard-serverside/dependency_manager/legacy_helpers'
+require 'engineyard-serverside/nginx_conf'
 
 module EY
   module Serverside
@@ -36,6 +37,7 @@ module EY
           setup_sqlite3_if_necessary
           run_with_callbacks(:compile_assets) # defined in RailsAssetSupport
           enable_maintenance_page
+          process_custom_nginx_conf
           run_with_callbacks(:migrate)
           callback(:before_symlink)
           # We don't use run_with_callbacks for symlink because we need
@@ -112,6 +114,10 @@ module EY
 
       def disable_maintenance_page
         maintenance.conditionally_disable
+      end
+
+      def process_custom_nginx_conf
+        nginx_conf.conditionally_process
       end
 
       def run_with_callbacks(task)
@@ -237,6 +243,7 @@ chmod 0700 #{path}
             shell.status "Restarting with previous release."
             enable_maintenance_page
             run_with_callbacks(:restart)
+            process_custom_nginx_conf
             disable_maintenance_page
             shell.status "Finished rollback at #{Time.now.asctime}"
           rescue Exception
@@ -533,6 +540,10 @@ defaults:
       def dependency_manager
         ensure_git_ssh_wrapper
         @dependency_manager ||= DependencyManager.new(servers, config, shell, self)
+      end
+
+      def nginx_conf
+        @nginx_conf ||= NginxConf.new(servers, config, shell, self)
       end
 
       def compile_assets

--- a/lib/engineyard-serverside/nginx_conf.rb
+++ b/lib/engineyard-serverside/nginx_conf.rb
@@ -1,0 +1,127 @@
+module EY
+  module Serverside
+    class NginxConf
+      attr_reader :servers, :config, :shell, :runner
+
+      def initialize(servers, config, shell, runner)
+        @servers, @config, @shell, @runner = servers, config, shell, runner
+      end
+
+      def nginx_conf?
+        paths.nginx_conf.exist?
+      end
+      
+      def nginx_sysconf_dir
+        "/etc/nginx/"
+      end
+
+      def custom_conf
+        "#{nginx_sysconf_dir}servers/#{config.app}/custom.conf"
+      end
+      
+      def app_current
+        paths.deploy_root
+      end
+
+      def temp_dir
+        "#{Dir.tmpdir}/nginx/#{paths.active_release}/"
+      end
+      
+      def detected?
+        nginx_conf?
+      end
+
+      def custom_conf?
+        begin
+          run "test -f '#{custom_conf}'"
+          return true
+        rescue EY::Serverside::RemoteFailure
+          return false
+        end
+      end
+
+      def enabled?
+          enabled = config['nginx_conf']
+          case enabled
+          when 'false', false
+            return false
+          when 'true',  true, nil
+            return true
+          else
+            raise "Unknown value #{enabled.inspect} for option nginx_conf. Expected [true, false]"
+          end
+      end
+
+      # Create a temporary directory based on current deploy
+      def make_temp_dir
+        "mkdir -p #{temp_dir}"
+      end
+
+      # Copy all current nginx configuration to temp so it can be manipulated
+      def copy_nginx_conf
+        "cp -R #{nginx_sysconf_dir}* #{temp_dir}"
+      end
+
+      # include paths are absolute, make relative for test
+      def replace_include_paths
+        "sed -i 's#include #{nginx_sysconf_dir}#include #g' #{temp_dir}nginx.conf"
+      end
+
+      # Replace references to current release with active release
+      def use_active_release
+        "sed -i 's##{app_current}/current##{paths.active_release}#g' #{temp_dir}sites-enabled/*.conf"
+      end
+
+      # Sets up the nginx configs in a temp directory
+      # with altered paths so the integrated config
+      # can be tested before making it production.
+      def create_testable_config
+        sudo "#{make_temp_dir} && #{copy_nginx_conf} && #{replace_include_paths} && #{use_active_release}"
+      end
+
+      # Run test as sudo: some nginx files are root owned, produces error otherwise
+      def test_and_cleanup
+        sudo "nginx -t -c #{temp_dir}nginx.conf && rm -rf #{temp_dir}"
+      end
+
+      def nginx_configtest
+        shell.status "Testing nginx configuration (nginx.conf detected)"
+        create_testable_config
+        test_and_cleanup
+      end
+
+      def conditionally_process
+        if enabled?
+          if detected?
+            if custom_conf?
+              shell.warning "nginx.conf detected, custom nginx rules should be placed in #{custom_conf}"
+            else
+              nginx_configtest
+            end
+          end
+        end
+      end
+
+      protected
+      def paths
+        config.paths
+      end
+
+      def on_roles
+        [:app_master, :app, :solo]
+      end
+
+      def run(cmd)
+        runner.roles(on_roles) do
+          runner.run(cmd)
+        end
+      end
+
+      def sudo(cmd)
+        runner.roles(on_roles) do
+          runner.sudo(cmd)
+        end
+      end
+    end
+  end
+end

--- a/lib/engineyard-serverside/paths.rb
+++ b/lib/engineyard-serverside/paths.rb
@@ -91,6 +91,7 @@ module EY
       def_path :active_release_config,    [:active_release, 'config']
       def_path :active_log,               [:active_release, 'log']
       def_path :active_tmp,               [:active_release, 'tmp']
+      def_path :nginx_conf,               [:active_release, 'nginx.conf']
 
       def initialize(opts)
         @opts             = opts

--- a/spec/fixtures/repos/php_composer_disabled/config/ey.yml
+++ b/spec/fixtures/repos/php_composer_disabled/config/ey.yml
@@ -1,2 +1,3 @@
 defaults:
   composer: false
+  nginx_conf: false

--- a/spec/fixtures/repos/php_composer_disabled/nginx.conf
+++ b/spec/fixtures/repos/php_composer_disabled/nginx.conf
@@ -1,0 +1,3 @@
+location /foo = {
+	rewrite ^/foo/? http://example.com last;
+}

--- a/spec/fixtures/repos/php_composer_lock/nginx.conf
+++ b/spec/fixtures/repos/php_composer_lock/nginx.conf
@@ -1,0 +1,3 @@
+location /foo = {
+	rewrite ^/foo/? http://example.com last;
+}

--- a/spec/fixtures/repos/php_no_composer_lock/nginx.conf
+++ b/spec/fixtures/repos/php_no_composer_lock/nginx.conf
@@ -1,0 +1,3 @@
+location /foo = {
+	rewrite ^/foo/? http://example.com last;
+}

--- a/spec/php_deploy_spec.rb
+++ b/spec/php_deploy_spec.rb
@@ -11,6 +11,10 @@ describe "Deploying an application that uses PHP and Composer" do
           deploy_test_application('php_composer_lock')
         end
 
+        it "runs nginx.conf integration" do
+          expect(@deployer.commands.grep(/nginx\.conf/)).not_to be_empty
+        end
+
         it "runs 'composer install'" do
           install_cmd = @deployer.commands.grep(/composer install/).first
           expect(install_cmd).not_to be_nil
@@ -33,13 +37,23 @@ describe "Deploying an application that uses PHP and Composer" do
         end
 
         it "does not run composer" do
-          expect(@deployer.commands.grep(/composer/)).to be_empty
+          expect(@deployer.commands.grep(/composer install/)).to be_empty
+        end
+
+        context "with nginx.conf disabled in ey.yml" do
+          it "does not run nginx.conf integration" do
+            expect(@deployer.commands.grep(/nginx\.conf/)).to be_empty
+          end
         end
       end
 
       context "WITHOUT a composer.lock but with composer.json" do
         before(:all) do
           deploy_test_application('php_no_composer_lock')
+        end
+
+        it "runs nginx.conf integration" do
+          expect(@deployer.commands.grep(/nginx\.conf/)).not_to be_empty
         end
 
         it "outputs a warning about deploying without a .lock" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,18 @@ module EY
   end
 end
 
+module EY
+  module Serverside
+    class NginxConf
+      def create_testable_config
+        # BSD/GNU differences too fiddly to test
+        true
+      end
+    end
+  end
+end
+
+
 module SpecDependencyHelpers
   $NPM_INSTALLED = system('which npm 2>&1')
   unless $NPM_INSTALLED
@@ -172,6 +184,13 @@ echo "Running composer with $@"
     SCRIPT
   end
 
+  def mock_nginx(&block)
+    mock_command('nginx', <<-SCRIPT, &block)
+#!/bin/bash
+echo "Running nginx with $@"
+    SCRIPT
+  end
+
   def mock_sudo(&block)
     mock_command('sudo', <<-SCRIPT, &block)
 #!/bin/bash
@@ -279,6 +298,7 @@ exec "$@"
     FullTestDeploy.on_create_callback = block
 
     mock_bundler(extra_config['bundle_install_fails'])
+    mock_nginx
     with_mocked_commands do
       capture do
         EY::Serverside::CLI.start(@argv)
@@ -308,6 +328,7 @@ exec "$@"
 
     FullTestDeploy.on_create_callback = block
 
+    mock_nginx
     mock_bundler(bundle_install_fails)
 
     with_mocked_commands do


### PR DESCRIPTION
On the new platform, uses an `nginx.conf` supplied in the root of a repo by a customer, and either fails or passes a deploy based on whether the fully integrated configuration passes an nginx configtest.

On Cloud, if an nginx.conf is detected, it provides a message informing customer of where custom nginx configuration should normally be placed, but performs no other action. Message can be disabled in `ey.yml` if desired.

This treats nginx.conf as sort of equivalent to a Gemfile or composer.json; something which is tied into an application's deployment workflow.
