### PR TITLE
Run configure command provided by the server that confirms app config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@
   * Add new ey.yml option `precompile_assets_command`
     Setting `precompile_assets_command` overrides the asset precompile rake command. (default: `rake assets:precompile RAILS_GROUPS=assets`)
     Bundler binstubs are in PATH so gem binaries will load through bundler.
+  * Supports the optional execution of a server defined configure script.
+    If found, the script can modify or load app settings to customize the server before deploy and abort if problems are encountered.
+    If the script does not exist, this step will be skipped and deploy will continue as usual.
   * In order to speed up asset compilation in Rails, the directory `/data/app/current/tmp` is now preserved between deploys to maintain assets cache.
     To disable this feature, set `shared_tmp: false` in `ey.yml`.
 

--- a/lib/engineyard-serverside/deploy.rb
+++ b/lib/engineyard-serverside/deploy.rb
@@ -32,6 +32,7 @@ module EY
           create_revision_file
           run_with_callbacks(:bundle)
           setup_services
+          configure_platform
           symlink_configs
           setup_sqlite3_if_necessary
           run_with_callbacks(:compile_assets) # defined in RailsAssetSupport
@@ -338,6 +339,21 @@ YML
 
           shell.substatus "Symlink database.yml"
           run "ln -nfs #{paths.shared_config}/database.sqlite3.yml #{paths.active_release_config}/database.yml"
+        end
+      end
+
+      def configure_platform
+        run configure_command
+      end
+
+      def configure_command
+        ENV['EY_SERVERSIDE_CONFIGURE_COMMAND'] || begin
+          configure_script = "/engineyard/bin/app_#{config.app}_configure"
+          return <<-CONFIGURE
+if [ -x "#{configure_script}" ] || which "#{configure_script}" >/dev/null 2>&1; then
+  EY_DEPLOY_APP='#{config.app}' EY_DEPLOY_RELEASE_PATH='#{paths.active_release.to_s}' #{configure_script};
+fi
+          CONFIGURE
         end
       end
 

--- a/spec/platform_configure_spec.rb
+++ b/spec/platform_configure_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe "Deploying an application with platform configure command" do
+  describe "configure script does not exist" do
+    before do
+      @releases_failed = deploy_dir.join('releases_failed')
+      deploy_test_application('default')
+    end
+
+    it "works without warning" do
+      expect(read_output).not_to match(/WARNING/)
+
+      expect(@releases_failed).not_to exist
+    end
+  end
+
+  describe "a succesful deploy" do
+    before do
+      @releases_failed = deploy_dir.join('releases_failed')
+      ENV['EY_SERVERSIDE_CONFIGURE_COMMAND'] = "echo platform_configure_command_ran >&2"
+      deploy_test_application('default')
+    end
+
+    after do
+      ENV.delete('EY_SERVERSIDE_CONFIGURE_COMMAND')
+    end
+
+    it "runs the configure_command during deploy and finishes successfully" do
+      expect(read_output).to match(/platform_configure_command_ran/)
+
+      expect(@releases_failed).not_to exist
+
+      restart = deploy_dir.join('current', 'restart')
+      expect(restart).to exist
+    end
+  end
+
+  describe "a failed configure command" do
+
+    before do
+      ENV['EY_SERVERSIDE_CONFIGURE_COMMAND'] = "echo platform_configure_command_failed >&2 && false"
+    end
+
+    after do
+      ENV.delete('EY_SERVERSIDE_CONFIGURE_COMMAND')
+    end
+
+    it "aborts the deplo when it fails, preventing the app from being restarted" do
+      @releases_failed = deploy_dir.join('releases_failed')
+      expect(@releases_failed).not_to exist
+
+      begin
+        deploy_test_application('default')
+      rescue
+      end
+      expect(read_output).to match(/platform_configure_command_failed/)
+
+      expect(@releases_failed.entries).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
If the command does not exist on the server, don't run it and continue
as usual. If the command exists, then run it and fail if it fails.

This allows the server to specify any sort of configuration loading and
application checking that it needs to do so extra features can be added
without extending serverside and synchronizing versions on the server
with features provided by the server.
