### PR TITLE
Convert specs to RSpec 2.99.2 syntax with Transpec

### DIFF
--- a/spec/archive_deploy_spec.rb
+++ b/spec/archive_deploy_spec.rb
@@ -20,7 +20,7 @@ describe "Deploying a simple application" do
       args.instances = [{ :hostname => "localhost", :roles => ["solo"], :name => "single" }]
       args.serverside_version = Gem::Version.create(EY::Serverside::VERSION.dup).release
       args.config = {
-        "deploy_to" => deploy_dir,
+        "deploy_to" => deploy_dir.to_s,
         "group"            => GROUP
       }
     end

--- a/spec/bundler_deploy_spec.rb
+++ b/spec/bundler_deploy_spec.rb
@@ -40,9 +40,8 @@ describe "Deploying an application that uses Bundler" do
     end
 
     it "generates bundler binstubs" do
-      pending "doesn't work with mocked bundler" do
-        expect(deploy_dir.join('current', 'ey_bundler_binstubs', 'rake')).to exist
-      end
+      pending "doesn't work with mocked bundler"
+      expect(deploy_dir.join('current', 'ey_bundler_binstubs', 'rake')).to exist
     end
   end
 
@@ -111,7 +110,7 @@ describe "Deploying an application that uses Bundler" do
   context "without a Gemfile.lock and ignoring the warning" do
     before(:all) do
       deploy_test_application('no_gemfile_lock', 'config' => {'ignore_gemfile_lock_warning' => true})
-      expect(@config.ignore_gemfile_lock_warning).to be_true
+      expect(@config.ignore_gemfile_lock_warning).to be_truthy
       @install_bundler_command = @deployer.commands.grep(/gem install bundler/).first
       @bundle_install_command  = @deployer.commands.grep(/bundle _#{VERSION_PATTERN}_ install/).first
     end

--- a/spec/deploy_hook_spec.rb
+++ b/spec/deploy_hook_spec.rb
@@ -49,7 +49,7 @@ describe "deploy hooks" do
     end
 
     it 'runs the hook' do
-      deploy_dir.join('current', 'before_restart.ran').should exist
+      expect(deploy_dir.join('current', 'before_restart.ran')).to exist
     end
   end
 
@@ -59,7 +59,7 @@ describe "deploy hooks" do
     end
 
     it 'does not run the hook' do
-      deploy_dir.join('current', 'before_restart.ran').should_not exist
+      expect(deploy_dir.join('current', 'before_restart.ran')).not_to exist
     end
 
     it 'outputs a message about the hook not being executable' do
@@ -83,7 +83,7 @@ describe "deploy hooks" do
 
     context "#run" do
       it "is available" do
-        expect(deploy_hook.eval_hook('respond_to?(:run)')).to be_true
+        expect(deploy_hook.eval_hook('respond_to?(:run)')).to be_truthy
       end
 
       it "runs commands like the shell does" do
@@ -96,8 +96,8 @@ describe "deploy hooks" do
       end
 
       it "returns true/false to indicate the command's success" do
-        expect(deploy_hook.eval_hook('run("true")')).to be_true
-        expect(deploy_hook.eval_hook('run("false")')).to be_false
+        expect(deploy_hook.eval_hook('run("true")')).to be_truthy
+        expect(deploy_hook.eval_hook('run("false")')).to be_falsey
       end
 
       it "raises when the bang method alternative is used" do
@@ -113,7 +113,7 @@ describe "deploy hooks" do
 
     context "#sudo" do
       it "is available" do
-        expect(deploy_hook.eval_hook('respond_to?(:sudo)')).to be_true
+        expect(deploy_hook.eval_hook('respond_to?(:sudo)')).to be_truthy
       end
 
       it "runs things with sudo" do
@@ -139,18 +139,18 @@ describe "deploy hooks" do
 
     context "capistrano-ish methods" do
       it "has them" do
-        expect(deploy_hook.eval_hook('respond_to?(:latest_release)    ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:previous_release)  ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:all_releases)      ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:current_path)      ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:shared_path)       ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:release_dir)       ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:failed_release_dir)')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:release_path)      ')).to be_true
+        expect(deploy_hook.eval_hook('respond_to?(:latest_release)    ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:previous_release)  ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:all_releases)      ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:current_path)      ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:shared_path)       ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:release_dir)       ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:failed_release_dir)')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:release_path)      ')).to be_truthy
       end
 
       it "shows a deprecation warning that asks you to use config to access these variables" do
-        expect(deploy_hook.eval_hook('shared_path.nil?')).to be_false
+        expect(deploy_hook.eval_hook('shared_path.nil?')).to be_falsey
         out = read_output
         expect(out).to include("Use of `shared_path` (via method_missing) is deprecated in favor of `config.shared_path` for improved error messages and compatibility.")
         expect(out).to match(%r|in .*/deploy/fake_test_hook.rb|)
@@ -189,7 +189,7 @@ describe "deploy hooks" do
       end
 
       it "is deprecated through the @node ivar" do
-        expect(deploy_hook.eval_hook('@node.nil?')).to be_false
+        expect(deploy_hook.eval_hook('@node.nil?')).to be_falsey
         out = read_output
         expect(out).to match(%r|Use of `@node` in deploy hooks is deprecated.|)
         expect(out).to match(%r|Please use `config.node`, which provides access to the same object.|)
@@ -197,7 +197,7 @@ describe "deploy hooks" do
       end
 
       it "is available" do
-        expect(deploy_hook.eval_hook('config.node.nil?')).to be_false
+        expect(deploy_hook.eval_hook('config.node.nil?')).to be_falsey
       end
 
       it "has indifferent access" do
@@ -214,11 +214,11 @@ describe "deploy hooks" do
 
     context "config" do
       it "is available" do
-        expect(deploy_hook.eval_hook('config.nil?')).to be_false
+        expect(deploy_hook.eval_hook('config.nil?')).to be_falsey
       end
 
       it "is deprecated through the @configuration ivar" do
-        expect(deploy_hook.eval_hook('@configuration.nil?')).to be_false
+        expect(deploy_hook.eval_hook('@configuration.nil?')).to be_falsey
         out = read_output
         expect(out).to match(%r|Use of `@configuration` in deploy hooks is deprecated.|)
         expect(out).to match(%r|Please use `config`, which provides access to the same object.|)
@@ -244,7 +244,7 @@ describe "deploy hooks" do
         :revision,
         :environment].each do |attribute|
         it "has the #{attribute.inspect} attribute for compatibility with chef-deploy" do
-          expect(deploy_hook.eval_hook("config.has_key?(#{attribute.inspect})")).to be_true
+          expect(deploy_hook.eval_hook("config.has_key?(#{attribute.inspect})")).to be_truthy
         end
       end
     end
@@ -351,11 +351,11 @@ describe "deploy hooks" do
       end
 
       it "has info, warning, debug, logged_system, and access to shell" do
-        expect(deploy_hook.eval_hook('respond_to?(:info)         ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:warning)      ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:debug)        ')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:logged_system)')).to be_true
-        expect(deploy_hook.eval_hook('respond_to?(:shell)        ')).to be_true
+        expect(deploy_hook.eval_hook('respond_to?(:info)         ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:warning)      ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:debug)        ')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:logged_system)')).to be_truthy
+        expect(deploy_hook.eval_hook('respond_to?(:shell)        ')).to be_truthy
       end
     end
   end

--- a/spec/lockfile_parser_spec.rb
+++ b/spec/lockfile_parser_spec.rb
@@ -59,27 +59,27 @@ describe "the bundler version retrieved from the lockfile" do
 
   context "checking for gems in the dependencies" do
     it "does not have any database adapters in a gemfile lock without them" do
-      expect(get_parser('1.0.6-no-bundler').any_database_adapter?).to be_false
+      expect(get_parser('1.0.6-no-bundler').any_database_adapter?).to be_falsey
     end
 
     it "has a database adapter in a Gemfile.lock with do_mysql" do
-      expect(get_parser('1.0.18-do_mysql').any_database_adapter?).to be_true
+      expect(get_parser('1.0.18-do_mysql').any_database_adapter?).to be_truthy
     end
 
     it "has a database adapter in a Gemfile.lock with mysql" do
-      expect(get_parser('1.0.18-mysql').any_database_adapter?).to be_true
+      expect(get_parser('1.0.18-mysql').any_database_adapter?).to be_truthy
     end
 
     it "has a database adapter in a Gemfile.lock with mysql2" do
-      expect(get_parser('1.0.18-mysql2').any_database_adapter?).to be_true
+      expect(get_parser('1.0.18-mysql2').any_database_adapter?).to be_truthy
     end
 
     it "has a database adapter in a Gemfile.lock with pg" do
-      expect(get_parser('1.0.18-pg').any_database_adapter?).to be_true
+      expect(get_parser('1.0.18-pg').any_database_adapter?).to be_truthy
     end
 
     it "has a database adapter in a Gemfile.lock with do_postgres" do
-      expect(get_parser('1.0.18-do_postgres').any_database_adapter?).to be_true
+      expect(get_parser('1.0.18-do_postgres').any_database_adapter?).to be_truthy
     end
   end
 

--- a/spec/maintenance_spec.rb
+++ b/spec/maintenance_spec.rb
@@ -23,22 +23,22 @@ describe EY::Serverside::Maintenance do
     it "lets you know if the app is in maintenance mode" do
       maintenance_status
       maintenance_output = read_output.split("\n").select{|l| l.match("Maintenance")}
-      maintenance_output.count.should == 1
-      maintenance_output.first.should match(/Maintenance page: down$/)
+      expect(maintenance_output.count).to eq(1)
+      expect(maintenance_output.first).to match(/Maintenance page: down$/)
 
       enable_maintenance
 
       maintenance_status
       maintenance_output = read_output.split("\n").select{|l| l.match("Maintenance")}
-      maintenance_output.count.should == 1
-      maintenance_output.first.should match(/Maintenance page: up$/)
+      expect(maintenance_output.count).to eq(1)
+      expect(maintenance_output.first).to match(/Maintenance page: up$/)
 
       disable_maintenance
 
       maintenance_status
       maintenance_output = read_output.split("\n").select{|l| l.match("Maintenance")}
-      maintenance_output.count.should == 1
-      maintenance_output.first.should match(/Maintenance page: down$/)
+      expect(maintenance_output.count).to eq(1)
+      expect(maintenance_output.first).to match(/Maintenance page: down$/)
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.8 with the following command:
    transpec
- 23 conversions
  from: be_true
    to: be_truthy
- 7 conversions
  from: be_false
    to: be_falsey
- 7 conversions
  from: obj.should
    to: expect(obj).to
- 3 conversions
  from: == expected
    to: eq(expected)
- 1 conversion
  from: obj.should_not
    to: expect(obj).not_to
- 1 conversion
  from: pending { do_something_fail }
    to: pending; do_something_fail

For more details: https://github.com/yujinakayama/transpec#supported-conversions
