### PR TITLE
Fixes a problem where integrate would not use the existing release path

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-  *
+  * Fixes a problem where integrate would not use the existing release path, thus breaking rollback and other deploy coordination that relies on having the same path between servers.
 
 ## v2.6.0 (2014-12-11)
 

--- a/lib/engineyard-serverside/paths.rb
+++ b/lib/engineyard-serverside/paths.rb
@@ -105,8 +105,10 @@ module EY
         Time.now.utc.strftime("%Y%m%d%H%M%S")
       end
 
+      # if active_release is already set, it's set because we're operating on
+      # an existing release. This happens during integrate
       def new_release!
-        @active_release = path(:releases, release_dirname)
+        @active_release ||= path(:releases, release_dirname)
       end
 
       # If no active release is defined, use current

--- a/spec/basic_deploy_spec.rb
+++ b/spec/basic_deploy_spec.rb
@@ -1,19 +1,26 @@
 require 'spec_helper'
 
 describe "Deploying a simple application" do
-  context "without Bundler" do
-    before(:all) do
-      deploy_test_application('not_bundled')
-    end
+  before(:all) do
+    deploy_test_application('not_bundled')
+  end
 
-    it "creates a REVISION file" do
-      expect(deploy_dir.join('current', 'REVISION')).to exist
-    end
+  it "creates a REVISION file" do
+    expect(deploy_dir.join('current', 'REVISION')).to exist
+  end
 
-    it "restarts the app servers" do
-      restart = deploy_dir.join('current', 'restart')
-      expect(restart).to exist
-      expect(restart.read.chomp).to eq(%|LANG="en_US.UTF-8" /engineyard/bin/app_rails31 deploy|)
-    end
+  it "restarts the app servers" do
+    restart = deploy_dir.join('current', 'restart')
+    expect(restart).to exist
+    expect(restart.read.chomp).to eq(%|LANG="en_US.UTF-8" /engineyard/bin/app_rails31 deploy|)
+  end
+
+  it "reuses the same active_release directory if a release_path is specified (such as in integrate)" do
+    path = @config.paths.active_release
+    expect(path.parent.children.size).to eq(1)
+
+    redeploy_test_application('config' => {'release_path' => path.to_s})
+
+    expect(path.parent.children.size).to eq(1)
   end
 end


### PR DESCRIPTION
This was breaking rollback and other deploy coordination that relies
on having the same path between servers.
