### PR TITLE
Fix two typos that caused undefined method exceptions

### DIFF
--- a/lib/engineyard-serverside/spawner.rb
+++ b/lib/engineyard-serverside/spawner.rb
@@ -80,9 +80,9 @@ module EY
             elsif pid == -1
               # waitpid encountered an error (as defined in linux waitpid manpage)
               # apparently it can leak through ruby's waitpid abstraction
-              raise "Fatal error encountered while waiting for a child process to exit. waitpid2 returned: [#{pid.inpsect}, #{status.inspect}].\nExpected one of children: #{@child_by_pid.keys.inspect}"
+              raise "Fatal error encountered while waiting for a child process to exit. waitpid2 returned: [#{pid.inspect}, #{status.inspect}].\nExpected one of children: #{@child_by_pid.keys.inspect}"
             else
-              raise "Unknown pid returned from waitpid2 => #{pid.inpsect}, #{status.inspect}.\nExpected one of children: #{@child_by_pid.keys.inspect}"
+              raise "Unknown pid returned from waitpid2 => #{pid.inspect}, #{status.inspect}.\nExpected one of children: #{@child_by_pid.keys.inspect}"
             end
           rescue Errno::ECHILD
             possible_children = false


### PR DESCRIPTION
Fix two misspellings of 'inspect' that caused unfriendly error messages to be raised when in an error state due to child processes not exiting correctly.