### PR TITLE
Export GIT_SSH explicitly for dependency manager install steps

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 ## v2.6.2 (2015-02-03)
 
   * Use newest bundler 1.7.9 as the default when no bundler is specified in the Gemfile.
+  * Fixes a typo that prevented a useful error message when a child process exits abnormally.
 
 ## v2.6.1 (2014-12-18)
 

--- a/lib/engineyard-serverside/dependency_manager/composer.rb
+++ b/lib/engineyard-serverside/dependency_manager/composer.rb
@@ -44,7 +44,7 @@ To fix this problem, commit your composer.lock to the repository and redeploy.
         end
 
         def composer_install
-          run "composer install --no-interaction --no-dev --optimize-autoloader --working-dir #{paths.active_release}"
+          run %{export GIT_SSH="#{ENV['GIT_SSH']}" && composer install --no-interaction --no-dev --optimize-autoloader --working-dir #{paths.active_release}}
         end
 
         def composer_selfupdate

--- a/lib/engineyard-serverside/dependency_manager/npm.rb
+++ b/lib/engineyard-serverside/dependency_manager/npm.rb
@@ -10,7 +10,7 @@ module EY
 
         def install
           shell.status "Installing npm packages (package.json detected)"
-          run "cd #{paths.active_release} && npm install"
+          run %{cd #{paths.active_release} && export GIT_SSH="#{ENV['GIT_SSH']}" && npm install}
         end
       end
     end


### PR DESCRIPTION
My impression before was that having it in the parent processes env would work. Now realizing that ssh doesn't send local process env, so that was an oversight on my part. This should fix it.