### PR TITLE
Fix serverside problems related to gem version mismatch

### DIFF
--- a/lib/engineyard-serverside/about.rb
+++ b/lib/engineyard-serverside/about.rb
@@ -25,17 +25,16 @@ module EY
       end
 
       def gem_binary
-        File.join(Gem.default_bindir, 'gem')
+        gem_bin_path = File.join(Gem.default_bindir, 'gem')
+        if File.exists?("/usr/local/ey_resin/bin/ruby")
+          "/usr/local/ey_resin/bin/ruby -rubygems #{gem_bin_path}"
+        else
+          gem_bin_path
+        end
       end
 
       def binary
-        resin_path = "/usr/local/ey_resin/ruby/bin/engineyard-serverside"
-        if File.exists?(resin_path)
-          resin_path
-        else
-          #gem relative path causes deploy hook failures if gem version mismatches with other app servers
-          File.expand_path("../../../bin/#{gem_name}", __FILE__)
-        end
+        File.expand_path("../../../bin/#{gem_name}", __FILE__)
       end
 
       def hook_executor

--- a/lib/engineyard-serverside/cli.rb
+++ b/lib/engineyard-serverside/cli.rb
@@ -192,7 +192,7 @@ module EY
       def propagate(servers, shell)
         shell.status "Verifying and propagating #{About.name_with_version} to all servers."
 
-        gem_binary = File.join(Gem.default_bindir, 'gem')
+        gem_binary = About.gem_binary
         remote_gem_file = File.join(Dir.tmpdir, About.gem_filename)
 
         # the [,)] is to stop us from looking for e.g. 0.5.1, seeing

--- a/lib/engineyard-serverside/maintenance.rb
+++ b/lib/engineyard-serverside/maintenance.rb
@@ -70,15 +70,7 @@ module EY
         run "mkdir -p #{maintenance_page_dirname}"
         public_system_symlink_warning
         @up = true
-        maintenance_page_html = File.read(source_path)
-        if source_path == EY::Serverside::Paths::DEFAULT_MAINTENANCE_PAGE
-          #run fans out to all app servers but the serverside version is only isntalled on the server being used to deploy
-          #so if the serveside version being used isn't installed on a given app server the cp command would fail, but this echo will still work
-          run "echo '#{maintenance_page_html}' > #{enabled_maintenance_page_pathname}"
-        else
-          #since other possible paths are in your app, cp should work
-          run "cp #{source_path} #{enabled_maintenance_page_pathname}"
-        end
+        run "cp #{source_path} #{enabled_maintenance_page_pathname}"
       end
 
       def disable

--- a/lib/engineyard-serverside/version.rb
+++ b/lib/engineyard-serverside/version.rb
@@ -1,5 +1,5 @@
 module EY
   module Serverside
-    VERSION = '2.6.8'
+    VERSION = '2.6.9pre3'
   end
 end


### PR DESCRIPTION
Adjust gem propagation to install the gem with a resin prefix (if
/usr/local/ey_resin/bin/ruby exists, which it only does on v5)

reverts previous workarounds for maintenance page and deploy hooks and
instead rely on proper gem propagation