### PR TITLE
Pass --production to npm install when in production env.

### DIFF
--- a/lib/engineyard-serverside/dependency_manager/npm.rb
+++ b/lib/engineyard-serverside/dependency_manager/npm.rb
@@ -10,7 +10,17 @@ module EY
 
         def install
           shell.status "Installing npm packages (package.json detected)"
-          run %{cd #{paths.active_release} && export GIT_SSH="#{ENV['GIT_SSH']}" && npm install}
+          run %{cd #{paths.active_release} && export GIT_SSH="#{ENV['GIT_SSH']}" && npm install #{npm_install_options.join(" ")}}
+        end
+
+        def npm_install_options
+          options = []
+          options += ['--production'] if npm_production?
+          options
+        end
+
+        def npm_production?
+          ENV['NODE_ENV'] == 'production'
         end
       end
     end


### PR DESCRIPTION
Without `--production` option, `npm install` will install all packages including those specified under `devDependencies` in package.json. Many people have complained that our default deployment installs packages that they don't need in production. This change will add `--production` option to `npm install` when `NODE_ENV` is `production`.

Note that this can break applications of people who added essential packages they need in production under the `devDependencies` instead of `dependencies` where they should be. Their deployment will not fail because `npm install` will still succeed, and testing in a staging environment with a non-production `NODE_ENV` will not help them anticipate this problem.
