### PR TITLE
Support-795: Create shared/node_modules/ for reuse across deployments.

### DIFF
--- a/lib/engineyard-serverside/dependency_manager/npm.rb
+++ b/lib/engineyard-serverside/dependency_manager/npm.rb
@@ -10,6 +10,7 @@ module EY
 
         def install
           shell.status "Installing npm packages (package.json detected)"
+          run "mkdir -p #{paths.shared_node_modules} && ln -nfs #{paths.shared_node_modules} #{paths.active_node_modules}"
           run %{cd #{paths.active_release} && export GIT_SSH="#{ENV['GIT_SSH']}" && npm install #{npm_install_options.join(" ")}}
         end
 

--- a/lib/engineyard-serverside/paths.rb
+++ b/lib/engineyard-serverside/paths.rb
@@ -68,6 +68,7 @@ module EY
       def_path :shared_log,               [:shared,         'log']
       def_path :shared_tmp,               [:shared,         'tmp']
       def_path :shared_config,            [:shared,         'config']
+      def_path :shared_node_modules,      [:shared,         'node_modules']
       def_path :shared_system,            [:shared,         'system']
       def_path :default_repository_cache, [:shared,         'cached-copy']
       def_path :enabled_maintenance_page, [:shared_system,  'maintenance.html']
@@ -90,6 +91,7 @@ module EY
       def_path :composer_lock,            [:active_release, 'composer.lock']
       def_path :active_release_config,    [:active_release, 'config']
       def_path :active_log,               [:active_release, 'log']
+      def_path :active_node_modules,      [:active_release, 'node_modules']
       def_path :active_tmp,               [:active_release, 'tmp']
 
       def initialize(opts)


### PR DESCRIPTION
Currently, on every deployment of a Node.js application, the `npm install` command is executed and it creates a node_modules directory where it will install the packages. This change provides a node_modules directory under the shared directory and symlink it to the active release directory right before the `npm install` step. This way, the `npm install` process is much faster if a previous deployment has already installed most of the packages. It is even instant if there's no new package added to package.json. This is similar to how we handle the Rails assets during deployment though not exactly the same.
