### PR TITLE
Revert CI builds back to Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
 
 sudo: false
 
+dist: precise
+
 notifications:
   recipients:
     - memde@engineyard.com


### PR DESCRIPTION
In addition to the issues around jdk_switcher.sh (see
https://github.com/travis-ci/travis-ci/issues/8906 ), it looks
like Composer is a bit problematic on the Trusty builds.

That being the case, rolling the CI build image back to Precise
for the time being to allow for further development while we
figure that out.