### PR TITLE
Fixed integration workflow

### DIFF
--- a/lib/engineyard-serverside/cli/app.rb
+++ b/lib/engineyard-serverside/cli/app.rb
@@ -119,7 +119,7 @@ module EY
         verbose_option
         desc "integrate", "Integrate other instances into this cluster"
         def integrate
-          Workflows.perform(:integrate, :options => options)
+          Workflows.perform(:integrate, options)
         end
 
         account_app_env_options

--- a/lib/engineyard-serverside/cli/workflows/integrating_servers.rb
+++ b/lib/engineyard-serverside/cli/workflows/integrating_servers.rb
@@ -7,18 +7,26 @@ module EY
 
         # IntegratingServers is a Workflow that attempts to integrate new
         # servers into an existing environment
-        class IntegratingServers
-          private
-          def procedure
+        class IntegratingServers < Base
+          def initialize(options = {})
+            super
+
+            # We need to set some extra options, but options is frozen by
+            # the time we get here, so dupe it!
+            @options = options.dup
+
             # so that we deploy to the same place there that we have here
-            integrate_options[:release_path] = current_app_dir.realpath.to_s
+            @options[:release_path] = current_app_dir.realpath.to_s
 
             # we have to deploy the same SHA there as here
-            integrate_options[:branch] = current_app_dir.join('REVISION').read.strip
+            @options[:branch] = current_app_dir.join('REVISION').read.strip
 
             # always rebundle gems on integrate to make sure the instance comes up correctly.
-            integrate_options[:clean] = true
+            @options[:clean] = true
+          end
 
+          private
+          def procedure
             propagate_serverside
 
             # We have to rsync the entire app dir, so we need all the permissions to be correct!


### PR DESCRIPTION
As a result of a premature PR merge around a year and a half back, the server integration workflow was a bit broken:

* It was being called incorrectly in the main CLI app
* It was not fully converted from the old format

These have both been rectified and verified on a live instance.