### PR TITLE
Implement a Railway

### DIFF
--- a/lib/railway.rb
+++ b/lib/railway.rb
@@ -1,0 +1,43 @@
+require 'result'
+
+module Railway
+  include Result::DSL
+
+  module DSL
+    def step(name, options = {})
+      with = options.delete(:with)
+      steps.push(:name => name, :with => with)
+    end
+
+    def steps
+      @steps ||= []
+    end
+  end
+
+  def self.included(base)
+    base.send :extend, DSL
+  end
+
+  def call(input = {})
+    steps = self.class.steps
+
+    return Failure('No steps') if steps.empty?
+
+    steps.
+      inject(Success(input)) {|result, step|
+        result.and_then {|data|
+          dispatch_step(step, data)
+        }
+      }
+  end
+
+  private
+  def dispatch_step(step, data)
+    begin
+      result = (step[:with] || self).send(step[:name], data)
+      result.is_a?(Result::Base) ? result : Success(result)
+    rescue => error
+      Failure(error)
+    end
+  end
+end

--- a/lib/result.rb
+++ b/lib/result.rb
@@ -1,0 +1,7 @@
+require 'result/dsl'
+require 'result/success'
+require 'result/failure'
+
+module Result
+  extend DSL
+end

--- a/lib/result/base.rb
+++ b/lib/result/base.rb
@@ -1,0 +1,41 @@
+module Result
+
+  class Base
+    def initialize(to_wrap)
+      @wrapped = to_wrap
+    end
+
+    def success?
+      false
+    end
+
+    def failure?
+      false
+    end
+
+    def value
+      raise "not present"
+    end
+
+    def error
+      raise "not present"
+    end
+
+    def and_then
+      self
+    end
+
+    def or_else
+      self
+    end
+
+    def on_success
+      self
+    end
+
+    def on_failure
+      self
+    end
+  end
+
+end

--- a/lib/result/dsl.rb
+++ b/lib/result/dsl.rb
@@ -1,0 +1,16 @@
+require 'result/success'
+require 'result/failure'
+
+module Result
+
+  module DSL
+    def Success(value)
+      Success.new(value)
+    end
+
+    def Failure(error)
+      Failure.new(error)
+    end
+  end
+
+end

--- a/lib/result/failure.rb
+++ b/lib/result/failure.rb
@@ -1,0 +1,29 @@
+require 'result/base'
+
+module Result
+
+  class Failure < Base
+    def initialize(to_wrap)
+      super
+      freeze
+    end
+
+    def error
+      @wrapped
+    end
+
+    def failure?
+      true
+    end
+
+    def or_else
+      yield error
+    end
+
+    def on_failure
+      yield error
+      super
+    end
+  end
+
+end

--- a/lib/result/success.rb
+++ b/lib/result/success.rb
@@ -1,0 +1,24 @@
+require 'result/base'
+
+module Result
+
+  class Success < Base
+    def value
+      @wrapped
+    end
+
+    def success?
+      true
+    end
+
+    def and_then
+      yield value
+    end
+
+    def on_success
+      yield value
+      super
+    end
+  end
+
+end

--- a/spec-inside/railway_spec.rb
+++ b/spec-inside/railway_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+require 'railway'
+
+class ComplicatedProcess
+  include Railway
+
+  step :step_1
+  step :step_2
+  step :step_3
+end
+
+class EmptyProcess
+  include Railway
+end
+
+describe Railway do
+  let(:steps) {[:step_1, :step_2, :step_3]}
+  let(:dummy) {ComplicatedProcess.new}
+
+  before(:each) do
+    steps.each do |step|
+      allow(dummy).to receive(step).and_return(Result.Success(nil))
+    end
+  end
+
+  describe '#call' do
+    let(:input) {nil}
+    let(:result) {dummy.call(input)}
+
+    it 'has a default argument' do
+      expect {dummy.call}.not_to raise_error
+    end
+
+    it 'passes the output of one step to the next step as input' do
+      allow(dummy).to receive(:step_1).and_return('step 1')
+      expect(dummy).to receive(:step_2).with('step 1').and_return('step 2')
+      expect(dummy).to receive(:step_3).with('step 2').and_return('step 3')
+
+      result
+    end
+
+    context 'when all steps are successful' do
+      it 'executes all steps' do
+        steps.each do |step|
+          expect(dummy).to receive(step).and_return(Result.Success(nil))
+        end
+
+        result
+      end
+
+      it 'returns a success' do
+        expect(result).to be_a(Result::Success)
+      end
+    end
+
+    context 'when a step fails' do
+      let(:failing_step) {:step_1}
+      let(:failure) {Result.Failure(nil)}
+
+      before(:each) do
+        allow(dummy).to receive(:step_1).and_return(failure)
+      end
+
+      it 'executes all steps up to that step' do
+        expect(dummy).to receive(:step_1).and_return(failure)
+
+        result
+      end
+
+      it 'does not execute steps after the failing step' do
+        (steps - [failing_step]).each do |step|
+          expect(dummy).not_to receive(step)
+        end
+
+        result
+      end
+
+      it 'returns the failure' do
+        expect(result).to eql(failure)
+      end
+    end
+
+    context 'when a step returns something other than a result' do
+      before(:each) do
+        steps.each do |step|
+          allow(dummy).to receive(step).and_return(step.to_s)
+        end
+      end
+
+      it 'treats the return value as a Success' do
+        expect(dummy).to receive(:step_2).with('step_1').and_return('step_2')
+        expect(dummy).to receive(:step_3).with('step_2').and_return('step_3')
+
+        expect(result).to be_a(Result::Success)
+        expect(result.value).to eql('step_3')
+      end
+    end
+
+    context 'when a step raises an error' do
+      let(:failing_step) {:step_1}
+      let(:error) {RuntimeError.new('a big nasty error')}
+
+      before(:each) do
+        allow(dummy).to receive(:step_1).and_raise(error)
+      end
+
+      it 'treats the step as a failure' do
+        (steps - [failing_step]).each do |step|
+          expect(dummy).not_to receive(step)
+        end
+
+        expect(result).to be_a(Result::Failure)
+        expect(result.error).to eql(error)
+      end
+    end
+
+    context 'when there are no steps' do
+      let(:dummy) {EmptyProcess.new}
+
+      it 'is a failure' do
+        expect(result).to be_a(Result::Failure)
+      end
+
+      it 'has an error regarding the lack of steps' do
+        expect(result.error).to eql('No steps')
+      end
+    end
+  end
+end

--- a/spec-inside/result/failure_spec.rb
+++ b/spec-inside/result/failure_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+require 'result/failure'
+
+module Result
+  describe Failure do
+    let(:dummy) {Object.new}
+    let(:wrapped) {3}
+    let(:result) {described_class.new(wrapped)}
+
+    before(:each) do
+      allow(dummy).to receive(:process)
+    end
+
+    it 'is a result' do
+      expect(result).to be_a(Result::Base)
+    end
+
+    it 'is frozen' do
+      expect(result).to be_frozen
+    end
+
+    describe '#success?' do
+      let(:success) {result.success?}
+
+      it 'is false' do
+        expect(success).to eql(false)
+      end
+    end
+
+    describe '#failure?' do
+      let(:failure) {result.failure?}
+
+      it 'is true' do
+        expect(failure).to eql(true)
+      end
+    end
+
+    describe '#value' do
+      let(:value) {result.value}
+
+      it 'raises an exception' do
+        expect {value}.to raise_exception
+      end
+    end
+
+    describe '#error' do
+      let(:error) {result.error}
+
+      it 'is the wrapped error' do
+        expect(error).to eql(wrapped)
+      end
+    end
+
+    describe '#and_then' do
+      it 'does not execute the given block' do
+        expect(dummy).not_to receive(:process)
+
+        result.and_then {|v| dummy.process(v)}
+      end
+
+      it 'is the failure itself' do
+        actual = result.and_then {|v| v}
+
+        expect(actual).to eql(result)
+      end
+    end
+
+    describe '#or_else' do
+
+      it 'yields the wrapped value to the block' do
+        expect(dummy).to receive(:process).with(wrapped)
+
+        result.or_else {|v| dummy.process(v)}
+      end
+
+      it 'is the result of the block' do
+        actual = result.or_else {|v| v + 1}
+
+        expect(actual).to eql(wrapped + 1)
+      end
+    end
+
+    describe '#on_success' do
+      it 'does not call the block' do
+        expect(dummy).not_to receive(:process)
+
+        result.on_success {|v| dummy.process(v)}
+      end
+
+      it 'is the failure itself' do
+        actual = result.on_success {|v| v}
+
+        expect(actual).to eql(result)
+      end
+    end
+
+    describe '#on_failure' do
+      it 'yields the wrapped value to the block' do
+        expect(dummy).to receive(:process).with(wrapped)
+
+        result.on_failure {|v| dummy.process(v)}
+      end
+
+      it 'is the failure itself' do
+        actual = result.on_failure {|v| v}
+
+        expect(actual).to eql(result)
+      end
+    end
+
+  end
+end

--- a/spec-inside/result/success_spec.rb
+++ b/spec-inside/result/success_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+require 'result/success'
+
+module Result
+  describe Success do
+    let(:dummy) {Object.new}
+    let(:wrapped) {3}
+    let(:result) {described_class.new(wrapped)}
+
+    before(:each) do
+      allow(dummy).to receive(:process)
+    end
+
+    it 'is a result' do
+      expect(result).to be_a(Result::Base)
+    end
+
+    describe '#success?' do
+      let(:success) {result.success?}
+
+      it 'is true' do
+        expect(success).to eql(true)
+      end
+    end
+
+    describe '#failure?' do
+      let(:failure) {result.failure?}
+
+      it 'is false' do
+        expect(failure).to eql(false)
+      end
+    end
+
+    describe '#value' do
+      let(:value) {result.value}
+
+      it 'is the wrapped value' do
+        expect(value).to eql(wrapped)
+      end
+    end
+
+    describe '#error' do
+      let(:error) {result.error}
+
+      it 'raises an exception' do
+        expect {error}.to raise_exception
+      end
+    end
+
+    describe '#and_then' do
+      it 'yields the wrapped value to the block' do
+        expect(dummy).to receive(:process).with(wrapped)
+
+        result.and_then {|v| dummy.process(v)}
+      end
+
+      it 'is the result of yielding the wrapped value to the block' do
+        actual = result.and_then {|v| v + 1}
+
+        expect(actual).to eql(wrapped + 1)
+      end
+    end
+
+    describe '#or_else' do
+      it 'does not call the block' do
+        expect(dummy).not_to receive(:process)
+
+        result.or_else {|v| dummy.process(v)}
+      end
+
+      it 'is the success itself' do
+        actual = result.or_else {|v| v}
+
+        expect(actual).to eql(result)
+      end
+    end
+
+    describe '#on_success' do
+      it 'yields the wrapped value to the block' do
+        expect(dummy).to receive(:process).with(wrapped)
+
+        result.on_success {|v| dummy.process(v)}
+      end
+
+      it 'is the success itself' do
+        actual = result.on_success {|v| v}
+
+        expect(actual).to eql(result)
+      end
+    end
+
+    describe '#on_failure' do
+      it 'does not call the block' do
+        expect(dummy).not_to receive(:process)
+
+        result.on_failure {|v| dummy.process(v)}
+      end
+
+      it 'is the success itself' do
+        actual = result.on_failure {|v| v}
+
+        expect(actual).to eql(result)
+      end
+    end
+
+
+  end
+end

--- a/spec-inside/result_spec.rb
+++ b/spec-inside/result_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+require 'result'
+
+describe Result do
+  let(:value) {3}
+
+  describe '.Success' do
+    let(:result) {described_class.Success(value)}
+
+    it 'is a success' do
+      expect(result).to be_a(described_class::Success)
+    end
+  end
+
+  describe '.Failure' do
+    let(:result) {described_class.Failure(value)}
+
+    it 'is a failure' do
+      expect(result).to be_a(described_class::Failure)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds both the `Result` monad (for handling success/failure as values) as well as a `Railway` mixin for defining multi-step, bail anywhere processes.

Resolves #160 