### PR TITLE
Feature/implement a release finalizer

### DIFF
--- a/lib/engineyard-serverside/slug/finalizer.rb
+++ b/lib/engineyard-serverside/slug/finalizer.rb
@@ -59,7 +59,13 @@ module EY
         end
 
         def finalize_command(data)
-          "rm -rf #{old_release_path(data)}"
+          [
+            "for release in #{all_releases(data)}/*",
+            %{do if [ -d "${release}" ] && [ "$(basename "${release}")" != "#{data[:release_name]}"]},
+            'then rm -rf "${release}"',
+            'fi',
+            'done'
+          ].join(' ; ')
         end
 
         def old_release_path(data)

--- a/lib/engineyard-serverside/slug/finalizer.rb
+++ b/lib/engineyard-serverside/slug/finalizer.rb
@@ -1,0 +1,80 @@
+require 'railway'
+require 'runner'
+
+module EY
+  module Serverside
+    module Slug
+
+      class Finalizer
+        include Railway
+        include Runner
+
+        step :finalize_remotes
+        step :finalize_local
+
+        attr_reader :config, :shell, :servers
+
+        def initialize(config, shell, servers)
+          @config = config
+          @shell = shell
+          @servers = servers
+        end
+
+        private
+        def finalize_remotes(data)
+          finalized = []
+
+          remotes.each do |remote|
+            if run_and_success?(remote_command(remote, data))
+              finalized.push(remote)
+            else
+              return Failure(
+                data.merge(
+                  :finalized => finalized,
+                  :error => "Could not finalize #{data[:release_name]} on #{remote.hostname}"
+                )
+              )
+            end
+          end
+
+          Success(data.merge(:finalized => finalized))
+        end
+
+        def finalize_local(data = {})
+          unless run_and_success?(finalize_command(data))
+            return Failure(data.merge(:error => "Could not finalize #{data[:release_name]} on the app master"))
+          end
+
+          data[:finalized].push(servers.first {|server| server.role == :app_master || server.role == :solo})
+
+          Success(data)
+        end
+
+        def remotes
+          servers.reject {|server| server.role == :app_master}
+        end
+
+        def remote_command(remote, data)
+          "ssh -i #{config.paths.internal_key} #{remote.user}@#{remote.hostname} '#{finalize_command(data)}'"
+        end
+
+        def finalize_command(data)
+          "rm -rf #{old_release_path(data)}"
+        end
+
+        def old_release_path(data)
+          "#{all_releases(data)}/#{data[:current_release_name]}"
+        end
+
+        def all_releases(data)
+          "#{app_path(data)}/releases"
+        end
+
+        def app_path(data)
+          "/data/#{data[:app_name]}"
+        end
+      end
+
+    end
+  end
+end

--- a/spec-inside/engineyard-serverside/slug/finalizer_spec.rb
+++ b/spec-inside/engineyard-serverside/slug/finalizer_spec.rb
@@ -1,0 +1,191 @@
+require 'ostruct'
+
+require 'spec_helper'
+
+require 'result'
+require 'engineyard-serverside/slug/finalizer'
+
+module EY
+  module Serverside
+    module Slug
+
+      describe Finalizer do
+        let(:release_name) {'123456789'}
+        let(:app_name) {'george'}
+        let(:internal_key) {'/path/to/internal/key'}
+        let(:paths) {Object.new}
+
+        let(:app_master) {
+          OpenStruct.new(
+            :hostname => 'server1',
+            :role => :app_master,
+            :user => 'deploy'
+          )
+        }
+
+        let(:app) {
+          OpenStruct.new(
+            :hostname => 'server2',
+            :role => :app,
+            :user => 'deployapp'
+          )
+        }
+
+        let(:util) {
+          OpenStruct.new(
+            :hostname => 'server1',
+            :role => :util,
+            :user => 'deployutil'
+          )
+        }
+
+        let(:servers) {[app_master, app, util]}
+
+        let(:config) {Object.new}
+        let(:shell) {Object.new}
+        let(:success) {Result::Success.new(nil)}
+        let(:failure) {Result::Failure.new(nil)}
+
+        let(:data) {
+          {
+            :app_name => app_name,
+            :release_name => release_name,
+            :config => config,
+            :shell => shell,
+            :servers => servers
+          }
+        }
+
+        let(:finalizer) {described_class.new(config, shell, servers)}
+
+        before(:each) do
+          allow(config).to receive(:paths).and_return(paths)
+
+          allow(paths).to receive(:internal_key).and_return(internal_key)
+        end
+
+        it 'is a Railway' do
+          expect(finalizer).to be_a(Railway)
+        end
+
+        it 'has the exact steps for distributing a packaged app' do
+          steps = described_class.steps.map {|s| s[:name]}
+
+          expect(steps).to eql(
+            [
+              :finalize_remotes,
+              :finalize_local
+            ]
+          )
+        end
+
+        describe '#finalize_remotes' do
+          let(:remotes) {[app, util]}
+          let(:result) {finalizer.send(:finalize_remotes, data)}
+
+          before(:each) do
+            remotes.each do |remote|
+              allow(finalizer).
+                to receive(:run_and_success?).
+                with(finalizer.send(:remote_command, remote, data)).
+                and_return(true)
+            end
+          end
+
+          it 'executes the enable command for each remote' do
+            remotes.each do |remote|
+              expect(finalizer).
+                to receive(:run_and_success?).
+                with(finalizer.send(:remote_command, remote, data)).
+                and_return(true)
+            end
+
+            result
+          end
+
+          context 'when any execution fails' do
+            before(:each) do
+              expect(finalizer).
+                to receive(:run_and_success?).
+                with(finalizer.send(:remote_command, app, data)).
+                and_return(false)
+
+              expect(finalizer).
+                not_to receive(:run_and_success?).
+                with(finalizer.send(:remote_command, util, data))
+            end
+
+            it 'is a failure' do
+              expect(result).to be_a(Result::Failure)
+            end
+
+            it 'records the enabling error' do
+              expect(result.error[:error]).
+                to eql("Could not finalize #{release_name} on #{app.hostname}")
+            end
+          end
+
+          context 'when all executions succeed' do
+            it 'is a success' do
+              expect(result).to be_a(Result::Success)
+            end
+
+            it 'records the successfully enabled servers' do
+              expect(result.value[:finalized]).to include(app)
+              expect(result.value[:finalized]).to include(util)
+            end
+          end
+        end
+
+        describe '#finalize_local' do
+          let(:local_data) {data.merge(:finalized => [app, util])}
+          let(:result) {finalizer.send(:finalize_local, local_data)}
+
+          it 'runs the local enable command' do
+            expect(finalizer).
+              to receive(:run_and_success?).
+              with(finalizer.send(:finalize_command, data))
+
+            result
+          end
+
+          context 'when execution fails' do
+            before(:each) do
+              allow(finalizer).
+                to receive(:run_and_success?).
+                with(finalizer.send(:finalize_command, data)).
+                and_return(false)
+            end
+
+            it 'is a failure' do
+              expect(result).to be_a(Result::Failure)
+            end
+
+            it 'records the error' do
+              expect(result.error[:error]).to eql("Could not finalize #{release_name} on the app master")
+            end
+          end
+
+          context 'when execution succeeds' do
+            before(:each) do
+              allow(finalizer).
+                to receive(:run_and_success?).
+                with(finalizer.send(:finalize_command, data)).
+                and_return(true)
+            end
+
+            it 'is a success' do
+              expect(result).to be_a(Result::Success)
+            end
+
+            it 'adds the app master to the enabled list' do
+              expect(result.value[:finalized]).to include(app_master)
+            end
+          end
+        end
+
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the time being, this just deletes all release directories that are not the new current release.

Resolves #168 