### PR TITLE
TEY-101: Write integration test for deploy hook execution

### DIFF
--- a/engineyard-serverside.gemspec
+++ b/engineyard-serverside.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('contracts', '= 0.9')
   s.add_development_dependency('aruba', '~> 0.14.14')
   s.add_development_dependency('factis', '~> 1.0.1')
+  s.add_development_dependency('devnull', '~> 0.1.3')
 
   s.required_rubygems_version = %q{>= 1.3.6}
   s.test_files = Dir.glob("spec/**/*") + Dir.glob("features/**/*")

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -175,12 +175,29 @@ Feature: Running A Deploy Hook
       | before_restart        |
       | after_restart         |
       | after_deploy          |
-  #Scenario: Running a callback with a Ruby service hook
 
-  #Scenario: Running a callback with an Executable service hook
+  Scenario Outline: Running a callback with botth service hooks and deploy hooks
+    Given my app has a <Callback Name> executable deploy hook
+    And I have a service named selective
+    Given my service has a <Callback Name> ruby hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> ruby hook for my service is executed
+    And the <Callback Name> executable deploy hook is executed
 
-  #Scenario: Running a callback with both Ruby and Executable service hooks
-
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
   #Scenario: Running a callback with both service hooks and deploy hooks
 
     #@failure

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -198,10 +198,37 @@ Feature: Running A Deploy Hook
       | before_restart        |
       | after_restart         |
       | after_deploy          |
-  #Scenario: Running a callback with both service hooks and deploy hooks
+
+
+  Scenario Outline: Executable hooks without the executable bit get skipped
+    Given my app has a <Callback Name> executable deploy hook
+    But my app's <Callback Name> executable deploy hook is not actually executable
+    And I have a service named selective
+    Given my service has a <Callback Name> executable hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> executable hook for my service is executed
+    But the <Callback Name> executable deploy hook is not executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
 
     #@failure
   #Scenario: Ruby hooks with syntax errors cause an error
+
+    #@failure
+  #Scenario: Ruby hook errors cause an error
 
     #@failure
   #Scenario: Executable hooks that are not actually executable cause an error

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -1,0 +1,109 @@
+Feature: Running A Deploy Hook
+  In order to inject needed extra steps into the deploy process, I want to be able
+  to provide hooks for various pre-defined callbacks. Meanwhile, serverside needs
+  to know how to execute such hooks.
+
+  Background:
+    Given my account name is TestAccount
+    And my app's name is george
+    And my app lives in an environment named george_fliggerbop
+    And the framework env for my environment is staging
+
+  Scenario Outline: Running a callback
+    When I run `engineyard-serverside hook <Callback Name> --app=george --environment-name=george_fliggerbop --account-name=TestAccount --framework-env=staging`
+    Then I see output indicating that the <Callback Name> hooks were processed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
+
+  Scenario Outline: Running a callback with no hooks present
+    Given my app has no deploy hooks
+    And my app has no service hooks
+    When I run the <Callback Name> callback
+    Then I see a notice that the <Callback Name> callback was skipped
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
+
+  Scenario Outline: Running a callback with a Ruby deploy hook
+    Given my app has a <Callback Name> ruby deploy hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> ruby deploy hook is executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
+
+  Scenario Outline: Running a callback with an Executable deploy hook
+    Given my app has a <Callback Name> executable deploy hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> executable deploy hook is executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
+  #Scenario Outline: Running a callback with an Executable deploy hook
+    #Given the george app has a <Callback Name> executable hook
+    #When I run `engineyard-serverside hook <Callback Name>`
+
+  #Scenario: Running a callback with both Ruby and Executable deploy hooks
+
+  #Scenario: Running a callback with a Ruby service hook
+
+  #Scenario: Running a callback with an Executable service hook
+
+  #Scenario: Running a callback with both Ruby and Executable service hooks
+
+  #Scenario: Running a callback with both service hooks and deploy hooks
+
+    #@failure
+  #Scenario: Ruby hooks with syntax errors cause an error
+
+    #@failure
+  #Scenario: Executable hooks that are not actually executable cause an error

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -250,7 +250,6 @@ Feature: Running A Deploy Hook
       | after_restart         |
       | after_deploy          |
 
-
     @failure
   Scenario Outline: Ruby hooks with syntax errors cause an error
     Given my app has a <Callback Name> ruby deploy hook
@@ -276,6 +275,3 @@ Feature: Running A Deploy Hook
       | before_restart        |
       | after_restart         |
       | after_deploy          |
-
-    #@failure
-  #Scenario: Executable hooks that are not actually executable cause an error

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -229,6 +229,7 @@ Feature: Running A Deploy Hook
     Given my app has a <Callback Name> ruby deploy hook
     But my app's <Callback Name> ruby deploy hook contains syntax errors
     When I run the <Callback Name> callback
+    Then I see the output
     Then I see a notice about the <Callback Name> syntax error
     And the <Callback Name> ruby deploy hook is not executed
 

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -110,6 +110,27 @@ Feature: Running A Deploy Hook
       | before_restart        |
       | after_restart         |
       | after_deploy          |
+
+  Scenario Outline: Running a callback with a Ruby service hook
+    Given I have a service named selective
+    And my service has a <Callback Name> ruby hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> ruby hook for my service is executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
   #Scenario: Running a callback with a Ruby service hook
 
   #Scenario: Running a callback with an Executable service hook

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -224,8 +224,29 @@ Feature: Running A Deploy Hook
       | after_restart         |
       | after_deploy          |
 
-    #@failure
-  #Scenario: Ruby hooks with syntax errors cause an error
+    @error
+  Scenario Outline: Ruby hooks with syntax errors cause an error
+    Given my app has a <Callback Name> ruby deploy hook
+    But my app's <Callback Name> ruby deploy hook contains syntax errors
+    When I run the <Callback Name> callback
+    Then I see a notice about the <Callback Name> syntax error
+    And the <Callback Name> ruby deploy hook is not executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
+
 
     #@failure
   #Scenario: Ruby hook errors cause an error

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -227,10 +227,12 @@ Feature: Running A Deploy Hook
     @error
   Scenario Outline: Ruby hooks with syntax errors cause an error
     Given my app has a <Callback Name> ruby deploy hook
-    But my app's <Callback Name> ruby deploy hook contains syntax errors
+    And I have a service named selective
+    And my service has a <Callback Name> ruby hook
+    But my service's <Callback Name> ruby hook contains syntax errors
     When I run the <Callback Name> callback
-    Then I see the output
     Then I see a notice about the <Callback Name> syntax error
+    But my service's <Callback Name> ruby hook is not executed
     And the <Callback Name> ruby deploy hook is not executed
 
     Examples:

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -251,8 +251,31 @@ Feature: Running A Deploy Hook
       | after_deploy          |
 
 
-    #@failure
-  #Scenario: Ruby hook errors cause an error
+    @failure
+  Scenario Outline: Ruby hooks with syntax errors cause an error
+    Given my app has a <Callback Name> ruby deploy hook
+    And I have a service named selective
+    And my service has a <Callback Name> ruby hook
+    But my service's <Callback Name> ruby hook is prone to errors
+    When I run the <Callback Name> callback
+    Then the <Callback Name> ruby hook for my service is executed
+    But I see a notice about the <Callback Name> exception
+    And the <Callback Name> ruby deploy hook is not executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
 
     #@failure
   #Scenario: Executable hooks that are not actually executable cause an error

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -152,6 +152,29 @@ Feature: Running A Deploy Hook
       | before_restart        |
       | after_restart         |
       | after_deploy          |
+
+  Scenario Outline: Running a callback with both Ruby and Executable service hooks
+    Given I have a service named selective
+    Given my service has a <Callback Name> executable hook
+    Given my service has a <Callback Name> ruby hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> ruby hook for my service is executed
+    But the <Callback Name> executable hook for my service is not executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
   #Scenario: Running a callback with a Ruby service hook
 
   #Scenario: Running a callback with an Executable service hook

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -131,6 +131,27 @@ Feature: Running A Deploy Hook
       | before_restart        |
       | after_restart         |
       | after_deploy          |
+
+  Scenario Outline: Running a callback with an executable service hook
+    Given I have a service named selective
+    And my service has a <Callback Name> executable hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> executable hook for my service is executed
+
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
   #Scenario: Running a callback with a Ruby service hook
 
   #Scenario: Running a callback with an Executable service hook

--- a/features/hook/running-a-deploy-hook.feature
+++ b/features/hook/running-a-deploy-hook.feature
@@ -88,12 +88,28 @@ Feature: Running A Deploy Hook
       | before_restart        |
       | after_restart         |
       | after_deploy          |
-  #Scenario Outline: Running a callback with an Executable deploy hook
-    #Given the george app has a <Callback Name> executable hook
-    #When I run `engineyard-serverside hook <Callback Name>`
 
-  #Scenario: Running a callback with both Ruby and Executable deploy hooks
+  Scenario Outline: Running a callback with both Ruby and Executable deploy hooks
+    Given my app has a <Callback Name> executable deploy hook
+    Given my app has a <Callback Name> ruby deploy hook
+    When I run the <Callback Name> callback
+    Then the <Callback Name> ruby deploy hook is executed
+    But the <Callback Name> executable deploy hook is not executed
 
+    Examples:
+      | Callback Name         |
+      | before_deploy         |
+      | before_bundle         |
+      | after_bundle          |
+      | before_compile_assets |
+      | after_compile_assets  |
+      | before_migrate        |
+      | after_migrate         |
+      | before_symlink        |
+      | after_symlink         |
+      | before_restart        |
+      | after_restart         |
+      | after_deploy          |
   #Scenario: Running a callback with a Ruby service hook
 
   #Scenario: Running a callback with an Executable service hook

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -161,7 +161,7 @@ Given %r{^my app's (.+) executable deploy hook is not actually executable$} do |
 end
 
 Given %r{^my app's (.+) ruby deploy hook contains syntax errors$} do |callback_name|
-  write_ruby_deploy_hook(callback_name, ')_!$')
+  write_ruby_deploy_hook(callback_name, "# encoding: UTF-8\n\n)_!$")
 end
 
 Then %r{^I see a notice about the (.+) syntax error$} do |callback_name|

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -80,9 +80,7 @@ def write_ruby_deploy_hook(callback_name, content)
 
   hook = deploy_hooks_path.join("#{callback_name}.rb")
 
-  f = File.open(hook.to_s, 'w')
-  f.write(content)
-  f.close
+  File.write(hook.to_s, content.to_s)
 end
 
 Given %r{^my app has a (.+) ruby deploy hook$} do |callback_name|
@@ -161,7 +159,7 @@ Given %r{^my app's (.+) executable deploy hook is not actually executable$} do |
 end
 
 Given %r{^my app's (.+) ruby deploy hook contains syntax errors$} do |callback_name|
-  write_ruby_deploy_hook(callback_name, "# encoding: UTF-8\n\n)_!$")
+  write_ruby_deploy_hook(callback_name, "# encoding: UTF-8\n\n)")
 end
 
 Then %r{^I see a notice about the (.+) syntax error$} do |callback_name|

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -79,6 +79,8 @@ end
 Then %r{^the (.+) executable deploy hook is executed$} do |callback_name|
   expected = "EY_DEPLOY_ACCOUNT_NAME=#{account_name} EY_DEPLOY_APP=#{app_name} EY_DEPLOY_CONFIG='{\"app\":\"#{app_name}\",\"environment_name\":\"#{env_name}\",\"account_name\":\"#{account_name}\",\"framework_env\":\"#{framework_env}\",\"release_path\":\"#{release_path}\",\"hook_name\":\"#{callback_name}\"}' EY_DEPLOY_CURRENT_ROLES='' EY_DEPLOY_ENVIRONMENT_NAME=#{env_name} EY_DEPLOY_FRAMEWORK_ENV=#{framework_env} EY_DEPLOY_RELEASE_PATH=#{release_path} EY_DEPLOY_VERBOSE=0 RAILS_ENV=#{framework_env} RACK_ENV=#{framework_env} NODE_ENV=#{framework_env} MERB_ENV=#{framework_env} #{project_root.join('bin', 'engineyard-serverside-execute-hook')} #{callback_name}"
 
+  puts "executed commands: '#{ExecutedCommands.executed}'"
+  puts "expected: '#{expected}'"
   expect(ExecutedCommands.executed).to include(expected)
 end
 

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -80,7 +80,9 @@ def write_ruby_deploy_hook(callback_name, content)
 
   hook = deploy_hooks_path.join("#{callback_name}.rb")
 
-  File.write(hook.to_s, content.to_s)
+  f = File.open(hook.to_s, 'w')
+  f.write(content.to_s)
+  f.close
 end
 
 Given %r{^my app has a (.+) ruby deploy hook$} do |callback_name|

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -1,0 +1,87 @@
+require 'fileutils'
+
+def account_name
+  recall_fact(:account_name)
+end
+
+def app_name
+  recall_fact(:app_name)
+end
+
+def env_name
+  recall_fact(:env_name)
+end
+
+def framework_env
+  recall_fact(:framework_env)
+end
+
+Given %r{^my account name is (.+)$} do |account_name|
+  memorize_fact(:account_name, account_name)
+end
+
+Given %r{^my app's name is (.+)$} do |app_name|
+  memorize_fact(:app_name, app_name)
+end
+
+Given %r{^my app lives in an environment named (.+)$} do |env_name|
+  memorize_fact(:env_name, env_name)
+end
+
+Given %r{^the framework env for my environment is (.+)$} do |framework_env|
+  memorize_fact(:framework_env, framework_env)
+end
+
+Then %r{^I see output indicating that the (.+) hooks were processed$} do |hook_name|
+  expect(output_text).to include(hook_name)
+end
+
+Given %{my app has no deploy hooks} do
+  cleanup_deploy_hooks_path
+  true
+end
+
+Given %{my app has no service hooks} do
+  cleanup_shared_hooks_path
+  true
+end
+
+When %r{^I run the (.+) callback$} do |callback_name|
+  #puts "Data: '#{Dir["#{data_path}/**/*"]}'"
+  step %(I run `engineyard-serverside hook #{callback_name} --app=#{app_name} --environment-name=#{env_name} --account-name=#{account_name} --framework-env=#{framework_env} --release-path=#{release_path}`)
+end
+
+Then %r{^I see a notice that the (.+) callback was skipped$} do |callback_name|
+  expect(output_text).to include("#{callback_name}. Skipping.")
+end
+
+Given %r{^my app has a (.+) ruby deploy hook$} do |callback_name|
+  setup_deploy_hooks_path
+  FileUtils.touch(deploy_hooks_path.join("#{callback_name}.rb"))
+end
+
+Then %r{^the (.+) ruby deploy hook is executed$} do |callback_name|
+  expect(output_text).
+    to include("Executing #{deploy_hooks_path.join("#{callback_name}.rb")}")
+end
+
+Given %r{^my app has a (.+) executable deploy hook$} do |callback_name|
+  setup_deploy_hooks_path
+
+  hook = deploy_hooks_path.join(callback_name)
+  f = File.open(hook.to_s, 'w')
+  f.write("#!/bin/bash\n\necho #{hook.to_s}")
+  f.close
+
+  hook.chmod(0755)
+end
+
+Then %r{^the (.+) executable deploy hook is executed$} do |callback_name|
+  expected = "EY_DEPLOY_ACCOUNT_NAME=#{account_name} EY_DEPLOY_APP=#{app_name} EY_DEPLOY_CONFIG='{\"app\":\"#{app_name}\",\"environment_name\":\"#{env_name}\",\"account_name\":\"#{account_name}\",\"framework_env\":\"#{framework_env}\",\"release_path\":\"#{release_path}\",\"hook_name\":\"#{callback_name}\"}' EY_DEPLOY_CURRENT_ROLES='' EY_DEPLOY_ENVIRONMENT_NAME=#{env_name} EY_DEPLOY_FRAMEWORK_ENV=#{framework_env} EY_DEPLOY_RELEASE_PATH=#{release_path} EY_DEPLOY_VERBOSE=0 RAILS_ENV=#{framework_env} RACK_ENV=#{framework_env} NODE_ENV=#{framework_env} MERB_ENV=#{framework_env} #{project_root.join('bin', 'engineyard-serverside-execute-hook')} #{callback_name}"
+
+  expect(ExecutedCommands.executed).to include(expected)
+end
+
+Then %{I see the output} do
+  puts "OUTPUT START\n\n#{output_text}\n\nOUTPUT END"
+end

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -77,10 +77,12 @@ Given %r{^my app has a (.+) executable deploy hook$} do |callback_name|
 end
 
 Then %r{^the (.+) executable deploy hook is executed$} do |callback_name|
-  expected = "EY_DEPLOY_ACCOUNT_NAME=#{account_name} EY_DEPLOY_APP=#{app_name} EY_DEPLOY_CONFIG='{\"app\":\"#{app_name}\",\"environment_name\":\"#{env_name}\",\"account_name\":\"#{account_name}\",\"framework_env\":\"#{framework_env}\",\"release_path\":\"#{release_path}\",\"hook_name\":\"#{callback_name}\"}' EY_DEPLOY_CURRENT_ROLES='' EY_DEPLOY_ENVIRONMENT_NAME=#{env_name} EY_DEPLOY_FRAMEWORK_ENV=#{framework_env} EY_DEPLOY_RELEASE_PATH=#{release_path} EY_DEPLOY_VERBOSE=0 RAILS_ENV=#{framework_env} RACK_ENV=#{framework_env} NODE_ENV=#{framework_env} MERB_ENV=#{framework_env} #{project_root.join('bin', 'engineyard-serverside-execute-hook')} #{callback_name}".split.sort
+  expected = "EY_DEPLOY_ACCOUNT_NAME=#{account_name} EY_DEPLOY_APP=#{app_name} EY_DEPLOY_CONFIG='{\"app\":\"#{app_name}\",\"environment_name\":\"#{env_name}\",\"account_name\":\"#{account_name}\",\"framework_env\":\"#{framework_env}\",\"release_path\":\"#{release_path}\",\"hook_name\":\"#{callback_name}\"}' EY_DEPLOY_CURRENT_ROLES='' EY_DEPLOY_ENVIRONMENT_NAME=#{env_name} EY_DEPLOY_FRAMEWORK_ENV=#{framework_env} EY_DEPLOY_RELEASE_PATH=#{release_path} EY_DEPLOY_VERBOSE=0 RAILS_ENV=#{framework_env} RACK_ENV=#{framework_env} NODE_ENV=#{framework_env} MERB_ENV=#{framework_env} #{project_root.join('bin', 'engineyard-serverside-execute-hook')} #{callback_name}".split.sort.join(' ')
 
-  candidates = ExecutedCommands.executed.map {|cmd| cmd.split.sort}
+  candidates = ExecutedCommands.executed.map {|cmd| cmd.split.sort.join(' ')}
 
+  puts "candidates: '#{candidates}'"
+  puts "expected: '#{expected}'"
   expect(candidates).to include(expected)
 end
 

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -77,11 +77,11 @@ Given %r{^my app has a (.+) executable deploy hook$} do |callback_name|
 end
 
 Then %r{^the (.+) executable deploy hook is executed$} do |callback_name|
-  expected = "EY_DEPLOY_ACCOUNT_NAME=#{account_name} EY_DEPLOY_APP=#{app_name} EY_DEPLOY_CONFIG='{\"app\":\"#{app_name}\",\"environment_name\":\"#{env_name}\",\"account_name\":\"#{account_name}\",\"framework_env\":\"#{framework_env}\",\"release_path\":\"#{release_path}\",\"hook_name\":\"#{callback_name}\"}' EY_DEPLOY_CURRENT_ROLES='' EY_DEPLOY_ENVIRONMENT_NAME=#{env_name} EY_DEPLOY_FRAMEWORK_ENV=#{framework_env} EY_DEPLOY_RELEASE_PATH=#{release_path} EY_DEPLOY_VERBOSE=0 RAILS_ENV=#{framework_env} RACK_ENV=#{framework_env} NODE_ENV=#{framework_env} MERB_ENV=#{framework_env} #{project_root.join('bin', 'engineyard-serverside-execute-hook')} #{callback_name}"
+  expected = "EY_DEPLOY_ACCOUNT_NAME=#{account_name} EY_DEPLOY_APP=#{app_name} EY_DEPLOY_CONFIG='{\"app\":\"#{app_name}\",\"environment_name\":\"#{env_name}\",\"account_name\":\"#{account_name}\",\"framework_env\":\"#{framework_env}\",\"release_path\":\"#{release_path}\",\"hook_name\":\"#{callback_name}\"}' EY_DEPLOY_CURRENT_ROLES='' EY_DEPLOY_ENVIRONMENT_NAME=#{env_name} EY_DEPLOY_FRAMEWORK_ENV=#{framework_env} EY_DEPLOY_RELEASE_PATH=#{release_path} EY_DEPLOY_VERBOSE=0 RAILS_ENV=#{framework_env} RACK_ENV=#{framework_env} NODE_ENV=#{framework_env} MERB_ENV=#{framework_env} #{project_root.join('bin', 'engineyard-serverside-execute-hook')} #{callback_name}".split.sort
 
-  puts "executed commands: '#{ExecutedCommands.executed}'"
-  puts "expected: '#{expected}'"
-  expect(ExecutedCommands.executed).to include(expected)
+  candidates = ExecutedCommands.executed.map {|cmd| cmd.split.sort}
+
+  expect(candidates).to include(expected)
 end
 
 Then %{I see the output} do

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -26,6 +26,7 @@ end
 
 Given %r{^my app's name is (.+)$} do |app_name|
   memorize_fact(:app_name, app_name)
+  setup_release_path
 end
 
 Given %r{^my app lives in an environment named (.+)$} do |env_name|
@@ -76,7 +77,10 @@ end
 
 Given %r{^my app has a (.+) ruby deploy hook$} do |callback_name|
   setup_deploy_hooks_path
-  FileUtils.touch(deploy_hooks_path.join("#{callback_name}.rb"))
+  hook = deploy_hooks_path.join("#{callback_name}.rb")
+  f = File.open(hook.to_s, 'w')
+  f.write('true')
+  f.close
 end
 
 Then %r{^the (.+) ruby deploy hook is executed$} do |callback_name|
@@ -110,7 +114,11 @@ end
 Given %r{^my service has a (.+) ruby hook$} do |callback_name|
   setup_service_path(service_name)
 
-  FileUtils.touch(service_path(service_name).join("#{callback_name}.rb"))
+  hook = service_path(service_name).join("#{callback_name}.rb")
+
+  f = File.open(hook.to_s, 'w')
+  f.write('true')
+  f.close
 end
 
 Then %r{^the (.+) ruby hook for my service is executed$} do |callback_name|

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -119,6 +119,27 @@ Then %r{^the (.+) ruby hook for my service is executed$} do |callback_name|
   expect(output_text).to include("Executing #{hook}")
 end
 
+Given %r{^my service has a (.+) executable hook$} do |callback_name|
+  setup_service_path(service_name)
+
+  hook = service_path(service_name).join(callback_name)
+  f = File.open(hook.to_s, 'w')
+  f.write("#!/bin/bash\n\necho #{hook.to_s}")
+  f.close
+
+  hook.chmod(0755)
+end
+
+Then %r{^the (.+) executable hook for my service is executed$} do |callback_name|
+  expect(ExecutedCommands.service_hook_executed?(service_name, callback_name)).
+    to eql(true)
+end
+
+Then %r{^the (.+) executable hook for my service is not executed$} do |callback_name|
+  expect(ExecutedCommands.service_hook_executed?(service_name, callback_name)).
+    to eql(false)
+end
+
 Then %{I see the output} do
   puts "OUTPUT START\n\n#{output_text}\n\nOUTPUT END"
 end

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -77,13 +77,11 @@ Given %r{^my app has a (.+) executable deploy hook$} do |callback_name|
 end
 
 Then %r{^the (.+) executable deploy hook is executed$} do |callback_name|
-  found = ExecutedCommands.
-    executed.
-    select {|x|
-      x.match(/engineyard-serverside-execute-hook #{callback_name}/)
-    }.length > 0
+  expect(ExecutedCommands.deploy_hook_executed?(callback_name)).to eql(true)
+end
 
-    expect(found).to eql(true)
+Then %r{^the (.+) executable deploy hook is not executed$} do |callback_name|
+  expect(ExecutedCommands.deploy_hook_executed?(callback_name)).to eql(false)
 end
 
 Then %{I see the output} do

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -77,13 +77,13 @@ Given %r{^my app has a (.+) executable deploy hook$} do |callback_name|
 end
 
 Then %r{^the (.+) executable deploy hook is executed$} do |callback_name|
-  expected = "EY_DEPLOY_ACCOUNT_NAME=#{account_name} EY_DEPLOY_APP=#{app_name} EY_DEPLOY_CONFIG='{\"app\":\"#{app_name}\",\"environment_name\":\"#{env_name}\",\"account_name\":\"#{account_name}\",\"framework_env\":\"#{framework_env}\",\"release_path\":\"#{release_path}\",\"hook_name\":\"#{callback_name}\"}' EY_DEPLOY_CURRENT_ROLES='' EY_DEPLOY_ENVIRONMENT_NAME=#{env_name} EY_DEPLOY_FRAMEWORK_ENV=#{framework_env} EY_DEPLOY_RELEASE_PATH=#{release_path} EY_DEPLOY_VERBOSE=0 RAILS_ENV=#{framework_env} RACK_ENV=#{framework_env} NODE_ENV=#{framework_env} MERB_ENV=#{framework_env} #{project_root.join('bin', 'engineyard-serverside-execute-hook')} #{callback_name}".split.sort.join(' ')
+  found = ExecutedCommands.
+    executed.
+    select {|x|
+      x.match(/engineyard-serverside-execute-hook #{callback_name}/)
+    }.length > 0
 
-  candidates = ExecutedCommands.executed.map {|cmd| cmd.split.sort.join(' ')}
-
-  puts "candidates: '#{candidates}'"
-  puts "expected: '#{expected}'"
-  expect(candidates).to include(expected)
+    expect(found).to eql(true)
 end
 
 Then %{I see the output} do

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -140,6 +140,12 @@ Then %r{^the (.+) executable hook for my service is not executed$} do |callback_
     to eql(false)
 end
 
+Given %r{^my app's (.+) executable deploy hook is not actually executable$} do |callback_name|
+  hook = deploy_hooks_path.join(callback_name)
+
+  hook.chmod(0644)
+end
+
 Then %{I see the output} do
   puts "OUTPUT START\n\n#{output_text}\n\nOUTPUT END"
 end

--- a/features/hook/step_definitions/running-a-deploy-hook-steps.rb
+++ b/features/hook/step_definitions/running-a-deploy-hook-steps.rb
@@ -179,6 +179,17 @@ Then %r(^my service's (.+) ruby hook is not executed$) do |callback_name|
   expect(output_text).not_to include("Executing #{hook}")
 end
 
+Given %r{^my service's (.+) ruby hook is prone to errors$} do |callback_name|
+  write_ruby_service_hook(callback_name, "raise 'a ruckus'")
+end
+
+Then %r{^I see a notice about the (.+) exception$} do |callback_name|
+  hook = service_path(service_name).join("#{callback_name}.rb")
+
+  expect(output_text).
+    to include("Exception raised in hook #{hook.to_s}")
+end
+
 Then %r{^the (.+) ruby deploy hook is not executed$} do |callback_name|
   expect(output_text).
     not_to include("Executing #{deploy_hooks_path.join("#{callback_name}.rb")}")

--- a/features/step_definitions/command_steps.rb
+++ b/features/step_definitions/command_steps.rb
@@ -1,0 +1,8 @@
+Then %(the command has an unsuccessful exit status) do
+  step %{the exit status should not be 0}
+  step %{the exit status should not be 255}
+end
+
+Then %(the command suffers a critical failure) do
+  step %{the exit status should be 255}
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,10 +34,12 @@ class Runatron
                   allow(Logger).to receive(:new).and_return($logger)
 
                   EY::Serverside::CLI::App.start(@argv)
+                  0
                 rescue StandardError => e
                   b = e.backtrace
                   @stderr.puts("#{b.shift}: #{e.message} (#{e.class})")
                   @stderr.puts(b.map {|s| "\tfrom #{s}"}.join("\n"))
+                  255
                 rescue SystemExit => e
                   e.status
                 ensure

--- a/features/support/error_codes.rb
+++ b/features/support/error_codes.rb
@@ -1,0 +1,17 @@
+Before('@error') do
+  memorize_fact(:exit_status, 1)
+end
+
+Before('@failure') do
+  memorize_fact(:exit_status, 255)
+end
+
+After do
+  exit_status = begin
+                  recall_fact(:exit_status)
+                rescue
+                  0
+                end
+
+  step %{the exit status should be #{exit_status}}
+end

--- a/features/support/fs_helpers.rb
+++ b/features/support/fs_helpers.rb
@@ -1,0 +1,82 @@
+require 'pathname'
+module FsHelpers
+  def project_root
+    Pathname.new(File.expand_path(File.join(__FILE__, '..', '..', '..')))
+  end
+
+  def data_path
+    project_root.join('tmp', 'data')
+  end
+
+  def setup_data_path
+    data_path.mkpath
+  end
+
+  def cleanup_data_path
+    data_path.rmtree if data_path.exist?
+  end
+
+  def app_path
+    data_path.join(app_name)
+  end
+
+  def setup_app_path
+    app_path.mkpath
+  end
+
+  def release_path
+    app_path.join('20200212024800')
+  end
+
+  def setup_release_path
+    release_path.mkpath
+  end
+
+  def deploy_hooks_path
+    release_path.join('deploy')
+  end
+
+  def setup_deploy_hooks_path
+    deploy_hooks_path.mkpath
+  end
+
+  def cleanup_deploy_hooks_path
+    deploy_hooks_path.rmtree if deploy_hooks_path.exist?
+  end
+
+  def shared_app_path
+    app_path.join('shared')
+  end
+
+  def shared_hooks_path
+    shared_app_path.join('hooks')
+  end
+
+  def setup_shared_hooks_path
+    shared_hooks_path.mkpath
+  end
+
+  def cleanup_shared_hooks_path
+    shared_hooks_path.rmtree if shared_hooks_path.exist?
+  end
+
+  def service_path(service)
+    shared_hooks_path.join(service)
+  end
+
+  def setup_service_path(service)
+    service_path(service).mkpath
+  end
+
+  def setup_fs
+    setup_deploy_hooks_path
+    setup_shared_hooks_path
+  end
+
+  def cleanup_fs
+    cleanup_data_path
+  end
+
+end
+
+World(FsHelpers)

--- a/features/support/runner.rb
+++ b/features/support/runner.rb
@@ -1,0 +1,28 @@
+require 'runner'
+require 'engineyard-serverside/spawner'
+
+module ExecutedCommands
+  def self.record(cmd)
+    executed.push(cmd)
+
+    EY::Serverside::Spawner::Result.new(cmd, true, nil, nil)
+  end
+
+  def self.executed
+    @executed ||= []
+  end
+
+  def self.reset
+    @executed = nil
+  end
+
+  def self.hook_executed?(path)
+    executed.select {|x| x.match(/#{Regexp.escape(path)}/)}.length > 0
+  end
+end
+
+module Runner
+  def run(cmd)
+    ExecutedCommands.record(cmd)
+  end
+end

--- a/features/support/runner.rb
+++ b/features/support/runner.rb
@@ -16,9 +16,13 @@ module ExecutedCommands
     @executed = nil
   end
 
-  def self.hook_executed?(path)
-    executed.select {|x| x.match(/#{Regexp.escape(path)}/)}.length > 0
+  def self.deploy_hook_executed?(callback_name)
+    executed.
+      select {|x|
+        x.match(%r{engineyard-serverside-execute-hook #{callback_name}})
+      }.length > 0
   end
+
 end
 
 module Runner

--- a/features/support/runner.rb
+++ b/features/support/runner.rb
@@ -23,6 +23,15 @@ module ExecutedCommands
       }.length > 0
   end
 
+  def self.service_hook_executed?(service_name, callback_name)
+    executed.
+      select {|x|
+        x.match(
+          %r{engineyard-serverside-execute-service-hook #{service_name}/#{callback_name}}
+        )
+      }.length > 0
+  end
+
 end
 
 module Runner

--- a/lib/engineyard-serverside/callbacks/executor/ruby/executor.rb
+++ b/lib/engineyard-serverside/callbacks/executor/ruby/executor.rb
@@ -80,6 +80,7 @@ module EY
 
             def validate_hook(input = {})
               output = `#{ruby_bin} -c #{hook_path} 2>&1`
+              puts "hook validation output: '#{output}'"
               unless output =~ /Syntax OK/
                 return Failure(
                   input.merge(

--- a/lib/engineyard-serverside/callbacks/executor/ruby/executor.rb
+++ b/lib/engineyard-serverside/callbacks/executor/ruby/executor.rb
@@ -80,7 +80,6 @@ module EY
 
             def validate_hook(input = {})
               output = `#{ruby_bin} -c #{hook_path} 2>&1`
-              puts "hook validation output: '#{output}'"
               unless output =~ /Syntax OK/
                 return Failure(
                   input.merge(


### PR DESCRIPTION
```gherkin
Feature: Running A Deploy Hook
  In order to inject needed extra steps into the deploy process, I want to be able
  to provide hooks for various pre-defined callbacks. Meanwhile, serverside needs
  to know how to execute such hooks.

  Background:
    Given my account name is TestAccount
    And my app's name is george
    And my app lives in an environment named george_fliggerbop
    And the framework env for my environment is staging

  Scenario Outline: Running a callback
    When I run `engineyard-serverside hook <Callback Name> --app=george --environment-name=george_fliggerbop --account-name=TestAccount --framework-env=staging`
    Then I see output indicating that the <Callback Name> hooks were processed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with no hooks present
    Given my app has no deploy hooks
    And my app has no service hooks
    When I run the <Callback Name> callback
    Then I see a notice that the <Callback Name> callback was skipped

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with a Ruby deploy hook
    Given my app has a <Callback Name> ruby deploy hook
    When I run the <Callback Name> callback
    Then the <Callback Name> ruby deploy hook is executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with an Executable deploy hook
    Given my app has a <Callback Name> executable deploy hook
    When I run the <Callback Name> callback
    Then the <Callback Name> executable deploy hook is executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with both Ruby and Executable deploy hooks
    Given my app has a <Callback Name> executable deploy hook
    Given my app has a <Callback Name> ruby deploy hook
    When I run the <Callback Name> callback
    Then the <Callback Name> ruby deploy hook is executed
    But the <Callback Name> executable deploy hook is not executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with a Ruby service hook
    Given I have a service named selective
    And my service has a <Callback Name> ruby hook
    When I run the <Callback Name> callback
    Then the <Callback Name> ruby hook for my service is executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with an executable service hook
    Given I have a service named selective
    And my service has a <Callback Name> executable hook
    When I run the <Callback Name> callback
    Then the <Callback Name> executable hook for my service is executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with both Ruby and Executable service hooks
    Given I have a service named selective
    Given my service has a <Callback Name> executable hook
    Given my service has a <Callback Name> ruby hook
    When I run the <Callback Name> callback
    Then the <Callback Name> ruby hook for my service is executed
    But the <Callback Name> executable hook for my service is not executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

  Scenario Outline: Running a callback with botth service hooks and deploy hooks
    Given my app has a <Callback Name> executable deploy hook
    And I have a service named selective
    Given my service has a <Callback Name> ruby hook
    When I run the <Callback Name> callback
    Then the <Callback Name> ruby hook for my service is executed
    And the <Callback Name> executable deploy hook is executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |


  Scenario Outline: Executable hooks without the executable bit get skipped
    Given my app has a <Callback Name> executable deploy hook
    But my app's <Callback Name> executable deploy hook is not actually executable
    And I have a service named selective
    Given my service has a <Callback Name> executable hook
    When I run the <Callback Name> callback
    Then the <Callback Name> executable hook for my service is executed
    But the <Callback Name> executable deploy hook is not executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

    @error
  Scenario Outline: Ruby hooks with syntax errors cause an error
    Given my app has a <Callback Name> ruby deploy hook
    And I have a service named selective
    And my service has a <Callback Name> ruby hook
    But my service's <Callback Name> ruby hook contains syntax errors
    When I run the <Callback Name> callback
    Then I see a notice about the <Callback Name> syntax error
    But my service's <Callback Name> ruby hook is not executed
    And the <Callback Name> ruby deploy hook is not executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |

    @failure
  Scenario Outline: Ruby hooks with syntax errors cause an error
    Given my app has a <Callback Name> ruby deploy hook
    And I have a service named selective
    And my service has a <Callback Name> ruby hook
    But my service's <Callback Name> ruby hook is prone to errors
    When I run the <Callback Name> callback
    Then the <Callback Name> ruby hook for my service is executed
    But I see a notice about the <Callback Name> exception
    And the <Callback Name> ruby deploy hook is not executed

    Examples:
      | Callback Name         |
      | before_deploy         |
      | before_bundle         |
      | after_bundle          |
      | before_compile_assets |
      | after_compile_assets  |
      | before_migrate        |
      | after_migrate         |
      | before_symlink        |
      | after_symlink         |
      | before_restart        |
      | after_restart         |
      | after_deploy          |
```